### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   compile:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: fontist/setup-fontist@v2


### PR DESCRIPTION
Potential fix for [https://github.com/yunanwg/brilliant-CV/security/code-scanning/1](https://github.com/yunanwg/brilliant-CV/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the workflow, at the root level or specifically for the `compile` job. The best minimal fix is to specify `permissions: contents: read` for the `compile` job, as it does not need any write permissions—the only thing it does is check out code, run some compilation, and upload an artifact. Write access (for publishing) is already restricted only to the `deploy` job. Therefore, add the following block under line 10 in the `compile` job:

```yaml
permissions:
  contents: read
```

No additional methods, external libraries, or definitions are needed outside the workflow file. This fix explicitly restricts the permissions of the `GITHUB_TOKEN` as recommended.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
