### PR TITLE
feat: add footer display option to CV and letter templates

### DIFF
--- a/cv.typ
+++ b/cv.typ
@@ -200,6 +200,11 @@
   let lastName = metadata.personal.last_name
   let footerText = metadata.lang.at(metadata.language).cv_footer
   let ifDisplayPageCounter = metadata.layout.at("footer", default: {}).at("display_page_counter", default: false)
+  let ifDisplayFooter = metadata.layout.at("footer", default: {}).at("display_footer", default: true)
+
+  if not ifDisplayFooter {
+    return none
+  }
 
   // Styles
   let footerStyle(str) = {

--- a/letter.typ
+++ b/letter.typ
@@ -56,6 +56,11 @@
   let firstName = metadata.personal.first_name
   let lastName = metadata.personal.last_name
   let footerText = metadata.lang.at(metadata.language).letter_footer
+  let ifDisplayFooter = metadata.layout.at("footer", default: {}).at("display_footer", default: true)
+
+  if not ifDisplayFooter {
+    return none
+  }
 
   // Styles
   let footerStyle(str) = {

--- a/metadata.toml.schema.json
+++ b/metadata.toml.schema.json
@@ -107,6 +107,10 @@
         "footer": {
           "type": "object",
           "properties": {
+            "display_footer": {
+              "type": "boolean",
+              "description": "Display footer or not"
+            },
             "display_page_counter": {
               "type": "boolean",
               "description": "Display page counter in footer or not"

--- a/template/metadata.toml
+++ b/template/metadata.toml
@@ -45,6 +45,9 @@ language = "en"
         # Decide if you want to display page counter or not
         display_page_counter = false
 
+        # Decide if you want to display the footer or not
+        display_footer = true
+
 
 [inject]
     # Decide if you want to inject AI prompt or not


### PR DESCRIPTION
Implement #132 

- Introduced a new metadata property `display_footer` to control the visibility of footers in both CV and letter templates.
- Updated the footer rendering logic to conditionally return none if the footer is not to be displayed.
- Enhanced the metadata schema to include the new footer display option.