### PR TITLE
fix: update text settings in lib.typ to include fill color

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -40,7 +40,7 @@
   }
 
   // Page layout
-  set text(font: fonts, weight: "regular", size: 9pt)
+  set text(font: fonts, weight: "regular", size: 9pt, fill: _regular-colors.lightgray)
   set align(left)
   let paper_size = metadata.layout.at("paper_size", default: "a4")
   set page(
@@ -89,7 +89,7 @@
   }
 
   // Page layout
-  set text(font: fonts, weight: "regular", size: 9pt)
+  set text(font: fonts, weight: "regular", size: 9pt, fill: _regular-colors.lightgray)
   set align(left)
   let paper-size = metadata.layout.at("paper_size", default: "a4")
   set page(


### PR DESCRIPTION
Fix #130 

- Added fill color (_regular-colors.lightgray) to text settings in two locations for improved visibility in page layout.