### PR TITLE
refactor: introduce cv-metadata state and update metadata handling

### DIFF
--- a/src/cv.typ
+++ b/src/cv.typ
@@ -7,6 +7,9 @@
 #import "./utils/styles.typ": _latin-font-list, _latin-header-font, _awesome-colors, _regular-colors, _set-accent-color, h-bar
 #import "./utils/lang.typ": _is-non-latin, _default-date-width
 
+/// Metadata state to avoid passing metadata to every function
+#let cv-metadata = state("cv-metadata", none)
+
 /// Create header style functions
 /// -> dictionary
 #let _header-styles(header-font, regular-colors, accent-color, header-info-font-size) = (
@@ -271,12 +274,13 @@
   title,
   highlighted: true,
   letters: 3,
-  metadata: metadata,
+  metadata: none,
   // New parameter names (recommended)
   awesome-colors: none,
   // Old parameter names (deprecated, for backward compatibility)
   awesomeColors: _awesome-colors,
-) = {
+) = context {
+  let metadata = if metadata != none { metadata } else { cv-metadata.get() }
   // Backward compatibility logic (remove this block when deprecating)
   let awesome-colors = if awesome-colors != none { 
     awesome-colors 
@@ -684,12 +688,13 @@
   description: "Description",
   logo: "",
   tags: (),
-  metadata: metadata,
+  metadata: none,
   // New parameter names (recommended)
   awesome-colors: none,
   // Old parameter names (deprecated, for backward compatibility)
   awesomeColors: _awesome-colors,
-) = {
+) = context {
+  let metadata = if metadata != none { metadata } else { cv-metadata.get() }
   let params = _prepare-entry-params(metadata, awesome-colors, awesomeColors)
 
   _make-cv-entry(
@@ -718,12 +723,13 @@
   society: "Society",
   location: "Location",
   logo: "",
-  metadata: metadata,
+  metadata: none,
   // New parameter names (recommended)
   awesome-colors: none,
   // Old parameter names (deprecated, for backward compatibility)
   awesomeColors: _awesome-colors,
-) = {
+) = context {
+  let metadata = if metadata != none { metadata } else { cv-metadata.get() }
   // To use cvEntryStart, you need to set display_entry_society_first to true in the metadata.toml file.
   if not metadata.layout.entry.display_entry_society_first {
     panic("display_entry_society_first must be true to use cvEntryStart")
@@ -746,12 +752,13 @@
   date: "Date",
   description: "Description",
   tags: (),
-  metadata: metadata,
+  metadata: none,
   // New parameter names (recommended)
   awesome-colors: none,
   // Old parameter names (deprecated, for backward compatibility)
   awesomeColors: _awesome-colors,
-) = {
+) = context {
+  let metadata = if metadata != none { metadata } else { cv-metadata.get() }
   // To use cv-entry-continued, you need to set display_entry_society_first to true in the metadata.toml file.
   if not metadata.layout.entry.display_entry_society_first {
     panic("display_entry_society_first must be true to use cvEntryContinued")
@@ -864,8 +871,9 @@
   url: "",
   location: "",
   awesome-colors: _awesome-colors,
-  metadata: metadata,
-) = {
+  metadata: none,
+) = context {
+  let metadata = if metadata != none { metadata } else { cv-metadata.get() }
   let accent-color = _set-accent-color(awesome-colors, metadata)
 
   let honor-date-style(str) = {

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -24,6 +24,10 @@
     // TODO: Add deprecation warning in future version
     profilePhoto 
   }
+
+  // Update metadata state
+  cv-metadata.update(metadata)
+
   // Non Latin Logic
   let lang = metadata.language
   let fonts = _latin-font-list

--- a/template/modules_en/certificates.typ
+++ b/template/modules_en/certificates.typ
@@ -1,8 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-honor
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-honor = cv-honor.with(metadata: metadata)
 
 
 #cv-section("Certificates & Awards")

--- a/template/modules_en/education.typ
+++ b/template/modules_en/education.typ
@@ -1,8 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-entry, h-bar
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-entry = cv-entry.with(metadata: metadata)
 
 
 #cv-section("Education")

--- a/template/modules_en/professional.typ
+++ b/template/modules_en/professional.typ
@@ -1,10 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-entry, cv-entry-start, cv-entry-continued
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-entry = cv-entry.with(metadata: metadata)
-#let cv-entry-start = cv-entry-start.with(metadata: metadata)
-#let cv-entry-continued = cv-entry-continued.with(metadata: metadata)
 
 
 #cv-section("Professional Experience")

--- a/template/modules_en/projects.typ
+++ b/template/modules_en/projects.typ
@@ -1,8 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-entry
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-entry = cv-entry.with(metadata: metadata)
 
 
 #cv-section("Projects & Associations")

--- a/template/modules_en/publications.typ
+++ b/template/modules_en/publications.typ
@@ -1,7 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-publication
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
 
 
 #cv-section("Publications")

--- a/template/modules_en/skills.typ
+++ b/template/modules_en/skills.typ
@@ -1,7 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-skill, cv-skill-with-level, cv-skill-tag, h-bar
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
 
 
 #cv-section("Skills")

--- a/template/modules_fr/certificates.typ
+++ b/template/modules_fr/certificates.typ
@@ -1,8 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-honor
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-honor = cv-honor.with(metadata: metadata)
 
 
 #cv-section("Certificates")

--- a/template/modules_fr/education.typ
+++ b/template/modules_fr/education.typ
@@ -1,8 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-entry, h-bar
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-entry = cv-entry.with(metadata: metadata)
 
 
 #cv-section("Formation")

--- a/template/modules_fr/professional.typ
+++ b/template/modules_fr/professional.typ
@@ -1,10 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-entry, cv-entry-start, cv-entry-continued
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-entry = cv-entry.with(metadata: metadata)
-#let cv-entry-start = cv-entry-start.with(metadata: metadata)
-#let cv-entry-continued = cv-entry-continued.with(metadata: metadata)
 
 
 #cv-section("Expérience Professionnelle")

--- a/template/modules_fr/projects.typ
+++ b/template/modules_fr/projects.typ
@@ -1,8 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-entry
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-entry = cv-entry.with(metadata: metadata)
 
 
 #cv-section("Projets & Associations")

--- a/template/modules_fr/publications.typ
+++ b/template/modules_fr/publications.typ
@@ -1,7 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-publication
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
 
 
 #cv-section("Publications")

--- a/template/modules_fr/skills.typ
+++ b/template/modules_fr/skills.typ
@@ -1,7 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-skill, h-bar
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
 
 
 #cv-section("Compétences")

--- a/template/modules_it/certificates.typ
+++ b/template/modules_it/certificates.typ
@@ -1,8 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-honor
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-honor = cv-honor.with(metadata: metadata)
 
 
 #cv-section("Certificazioni")

--- a/template/modules_it/education.typ
+++ b/template/modules_it/education.typ
@@ -1,8 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-entry, h-bar
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-entry = cv-entry.with(metadata: metadata)
 
 
 #cv-section("Istruzione")

--- a/template/modules_it/professional.typ
+++ b/template/modules_it/professional.typ
@@ -1,10 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-entry, cv-entry-start, cv-entry-continued
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-entry = cv-entry.with(metadata: metadata)
-#let cv-entry-start = cv-entry-start.with(metadata: metadata)
-#let cv-entry-continued = cv-entry-continued.with(metadata: metadata)
 
 
 #cv-section("Esperienze di lavoro")

--- a/template/modules_it/projects.typ
+++ b/template/modules_it/projects.typ
@@ -1,8 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-entry
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-entry = cv-entry.with(metadata: metadata)
 
 
 #cv-section("Progetti")

--- a/template/modules_it/publications.typ
+++ b/template/modules_it/publications.typ
@@ -1,7 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-publication
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
 
 
 #cv-section("Pubblicazioni")

--- a/template/modules_it/skills.typ
+++ b/template/modules_it/skills.typ
@@ -1,7 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-skill, h-bar
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
 
 
 #cv-section("Competenze")

--- a/template/modules_zh/certificates.typ
+++ b/template/modules_zh/certificates.typ
@@ -1,8 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-honor
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-honor = cv-honor.with(metadata: metadata)
 
 
 #cv-section("证书")

--- a/template/modules_zh/education.typ
+++ b/template/modules_zh/education.typ
@@ -1,8 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-entry, h-bar
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-entry = cv-entry.with(metadata: metadata)
 
 
 #cv-section("教育经历")

--- a/template/modules_zh/professional.typ
+++ b/template/modules_zh/professional.typ
@@ -1,10 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-entry, cv-entry-start, cv-entry-continued
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-entry = cv-entry.with(metadata: metadata)
-#let cv-entry-start = cv-entry-start.with(metadata: metadata)
-#let cv-entry-continued = cv-entry-continued.with(metadata: metadata)
 
 
 #cv-section("职业经历")

--- a/template/modules_zh/projects.typ
+++ b/template/modules_zh/projects.typ
@@ -1,8 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-entry
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
-#let cv-entry = cv-entry.with(metadata: metadata)
 
 
 #cv-section("项目与协会")

--- a/template/modules_zh/publications.typ
+++ b/template/modules_zh/publications.typ
@@ -1,7 +1,5 @@
 // Imports
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-publication
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
 
 
 #cv-section("学术著作")

--- a/template/modules_zh/skills.typ
+++ b/template/modules_zh/skills.typ
@@ -1,7 +1,5 @@
 // Import
 #import "@preview/brilliant-cv:3.0.0": cv-section, cv-skill, h-bar
-#let metadata = toml("../metadata.toml")
-#let cv-section = cv-section.with(metadata: metadata)
 
 
 #cv-section("技能与兴趣")


### PR DESCRIPTION
Fix #54 

- Added a new state `cv-metadata` to manage metadata more efficiently, avoiding the need to pass it to every function.
- Updated function signatures to use `none` for metadata by default and retrieve it from `cv-metadata` when necessary.
- Removed redundant metadata passing in various template modules to streamline the code.