### PR TITLE
feat:custom content font size

### DIFF
--- a/docs/docs.typ
+++ b/docs/docs.typ
@@ -115,6 +115,9 @@ before_section_skip = "1pt"
 before_entry_skip = "1pt"
 before_entry_description_skip = "1pt"
 
+# Font size for the content text
+font_size = "9pt"
+
 [layout.header]
 # Optional values: left, center, right
 header_align = "left"

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -43,8 +43,11 @@
     header-font = nonLatinFont
   }
 
+  let font_size = eval(
+    metadata.layout.at("font_size", default: "9pt")
+  )
   // Page layout
-  set text(font: fonts, weight: "regular", size: 9pt, fill: _regular-colors.lightgray)
+  set text(font: fonts, weight: "regular", size: font_size, fill: _regular-colors.lightgray)
   set align(left)
   let paper_size = metadata.layout.at("paper_size", default: "a4")
   set page(

--- a/template/metadata.toml
+++ b/template/metadata.toml
@@ -20,6 +20,9 @@ language = "en"
     # Optional: sets the width of the right column of a cvEntry. If not set, values known to work well are used
     #date_width = "3.6cm"
 
+    # Optional: sets the font size for the content text
+    #font_size = "9pt"
+
     [layout.fonts]
         regular_fonts = ["Source Sans 3"]
         header_font = "Roboto"


### PR DESCRIPTION
add a configration `layout.font_size` to custom the font size

here is a example of `layout.font_size="11pt" 
<img width="1122" height="1590" alt="image" src="https://github.com/user-attachments/assets/d7f22913-6186-40bc-a5cc-e0a06e12430a" />
