### PR TITLE
fix: correct entry-start spacing when logos disabled

### DIFF
--- a/src/cv.typ
+++ b/src/cv.typ
@@ -459,19 +459,33 @@
     
   } else if entry-type == "start" {
     // Entry start layout (original cv-entry-start logic)
-    table(
-      columns: (if display-logo and logo != "" { 4% } else { 0% }, 1fr, date-width),
-      inset: 0pt,
-      stroke: 0pt,
-      gutter: 6pt,
-      align: horizon,
-      if logo == "" [] else {
-        set image(width: 100%)
-        logo
-      },
-      (styles.a1)(society),
-      (styles.a2)(location),
-    )
+    if display-logo and logo != "" {
+      // With logo: 3-column layout
+      table(
+        columns: (4%, 1fr, date-width),
+        inset: 0pt,
+        stroke: 0pt,
+        gutter: 6pt,
+        align: horizon,
+        {
+          set image(width: 100%)
+          logo
+        },
+        (styles.a1)(society),
+        (styles.a2)(location),
+      )
+    } else {
+      // Without logo: 2-column layout (matches cv-entry alignment)
+      table(
+        columns: (1fr, date-width),
+        inset: 0pt,
+        stroke: 0pt,
+        gutter: 6pt,
+        align: horizon,
+        (styles.a1)(society),
+        (styles.a2)(location),
+      )
+    }
     v(-10pt)
     
   } else if entry-type == "continued" {


### PR DESCRIPTION
## Summary

Fixes #143

When `display_logo = false`, the `cv-entry-start` layout had incorrect spacing because it used a 3-column table with a 0% first column, but the gutter still applied between columns causing misalignment with regular `cv-entry` components.

## Root Cause

The original code:
```typst
columns: (if display-logo and logo != "" { 4% } else { 0% }, 1fr, date-width)
gutter: 6pt
```

Even with a 0% column, the 6pt gutter creates space between the empty column and content.

## Solution

Use conditional layouts:
- **With logo**: 3-column layout `(4%, 1fr, date-width)`
- **Without logo**: 2-column layout `(1fr, date-width)` - matches `cv-entry` and `cv-entry-continued` alignment

## Test plan

- [x] Build with `display_logo = true` - PDFs identical (no regression)
- [x] Build with `display_logo = false` - alignment now matches cv-entry
- [x] Visual diff verified the spacing fix

## Note

This PR is based on #145 (remove duplicate functions) which should be merged first.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses spacing/misalignment in entry headers when `display_logo = false` and streamlines shared logic.
> 
> - **Layout fix**: `cv-entry-start` now uses a 3-column table when a logo is present and a 2-column `(1fr, date-width)` layout when absent, eliminating gutter-induced gaps and matching `cv-entry` alignment
> - **Refactor**: Consolidates `_prepare-entry-params` with clear backward-compat for `awesome-colors`/`awesomeColors`; reduces duplicate code
> - **Consistency**: Minor table/stroke adjustments in `_make-cv-entry`; preserves description and tag rendering behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e535f6670182e7f03230238538c0c7b1c3e881c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->