### PR TITLE
fix: cv-entry-continued description not using full page width with multiple dates

### DIFF
--- a/src/cv.typ
+++ b/src/cv.typ
@@ -521,10 +521,10 @@
         align: auto,
         {
           (styles.b1)(title)
-          (styles.description)(description)
         },
         (styles.b2)((styles.dates)(date)),
         )
+      (styles.description)(description)
       _create-entry-tag-list(tags, styles.tag)
     }
   }


### PR DESCRIPTION
## Summary
- Fixes a layout bug where `cv-entry-continued` description text does not use the full page width when multiple dates are present (i.e., `date` contains a `linebreak()`)
- The description was rendered inside the first cell of the `(1fr, date-width)` table, constraining its width; moved it outside the table to match the single-date branch and `cv-entry` behavior

Fixes #149

## Test plan
- [x] Use `cv-entry-continued` with a `linebreak()` in the `date` parameter and verify description text spans the full page width
- [x] Verify single-date `cv-entry-continued` still renders correctly
- [x] Verify `cv-entry` rendering is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)