### PR TITLE
feat: simplify keyword injection, deprecate inject_keywords

### DIFF
--- a/docs/docs.typ
+++ b/docs/docs.typ
@@ -139,8 +139,7 @@ display_logo = true
 # Custom AI prompt text (optional). If defined, it will be injected into the CV.
 # custom_ai_prompt_text = "Custom prompt text here..."
 
-# Decide if you want to inject keywords or not
-inject_keywords = true
+# Keywords to inject (optional). If defined, they will be injected into the CV.
 injected_keywords_list = ["Data Analyst", "GCP", "Python", "SQL", "Tableau"]
 
 [personal]

--- a/metadata.toml.schema.json
+++ b/metadata.toml.schema.json
@@ -138,21 +138,15 @@
           "type": "string",
           "description": "Custom AI prompt text. If defined, it will be injected into the CV."
         },
-        "inject_keywords": {
-          "type": "boolean",
-          "description": "Inject keywords or not"
-        },
         "injected_keywords_list": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "Keywords to inject into the CV. If defined, they will be injected."
         }
       },
-      "required": [
-        "inject_keywords",
-        "injected_keywords_list"
-      ]
+      "required": []
     },
     "personal": {
       "type": "object",

--- a/src/cv.typ
+++ b/src/cv.typ
@@ -174,13 +174,15 @@
 ) = {
   // Parameters
   let header-alignment = eval(metadata.layout.header.header_align)
-  // Backward compatibility: panic if old field is detected
+  // Backward compatibility: panic if old fields are detected
   if metadata.inject.at("inject_ai_prompt", default: none) != none {
     panic("'inject_ai_prompt' has been removed and will be fully deprecated in v4.0. Use 'custom_ai_prompt_text' in [inject] instead.")
   }
+  if metadata.inject.at("inject_keywords", default: none) != none {
+    panic("'inject_keywords' has been removed and will be fully deprecated in v4.0. Use 'injected_keywords_list' directly instead — if the list is present, keywords will be injected. To disable injection, remove 'injected_keywords_list'.")
+  }
   let custom-ai-prompt-text = metadata.inject.at("custom_ai_prompt_text", default: none)
-  let inject-keywords = metadata.inject.inject_keywords
-  let keywords = metadata.inject.injected_keywords_list
+  let keywords = metadata.inject.at("injected_keywords_list", default: ())
   let personal-info = metadata.personal.info
   let first-name = metadata.personal.first_name
   let last-name = metadata.personal.last_name
@@ -198,7 +200,6 @@
   // Injection
   _inject(
     custom-ai-prompt-text: custom-ai-prompt-text,
-    inject-keywords: inject-keywords,
     keywords: keywords,
   )
 

--- a/src/utils/injection.typ
+++ b/src/utils/injection.typ
@@ -4,8 +4,7 @@ A module containing the injection logic for the AI prompt and keywords.
 
 #let _inject(
   custom-ai-prompt-text: none,
-  inject-keywords: true,
-  keywords: [],
+  keywords: (),
 ) = {
   let parts = ()
 
@@ -13,7 +12,7 @@ A module containing the injection logic for the AI prompt and keywords.
     parts.push(custom-ai-prompt-text)
   }
 
-  if inject-keywords {
+  if keywords.len() > 0 {
     parts.push(keywords.join(" "))
   }
 

--- a/template/metadata.toml
+++ b/template/metadata.toml
@@ -56,8 +56,7 @@ language = "en"
     # Custom AI prompt text (optional). If defined, it will be injected into the CV.
     # custom_ai_prompt_text = "Custom prompt text here..."
 
-    # Decide if you want to inject keywords or not
-    inject_keywords = true
+    # Keywords to inject (optional). If defined, they will be injected into the CV.
     injected_keywords_list = ["Data Analyst", "GCP", "Python", "SQL", "Tableau"]
 
 [personal]


### PR DESCRIPTION
## Summary
- Remove the `inject_keywords` boolean toggle — keywords are now injected whenever `injected_keywords_list` is present in `[inject]`
- Add `panic()` when the old `inject_keywords` field is detected, with a clear migration message
- `inject_keywords` will be fully deprecated in v4.0

## Test plan
- [x] `just build` compiles successfully with default template
- [x] Adding `inject_keywords = true` to metadata.toml triggers panic with migration message

🤖 Generated with [Claude Code](https://claude.com/claude-code)