### PR TITLE
docs: add cv()/letter() examples and sync letter API docs

### DIFF
--- a/docs/web/docs/api-reference.md
+++ b/docs/web/docs/api-reference.md
@@ -23,7 +23,7 @@ Render a cover letter document with header, footer, and page layout applied.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `doc` | content | — | The body content of the letter. |
-| `sender-address` | str \| auto | `auto` | The sender's mailing address. Defaults to `auto`, which reads from `metadata.personal.address`. Pass a string or content to override. |
+| `sender-address` | str \| auto | `auto` | The sender's mailing address. Defaults to `auto`, which reads from `metadata.personal.address` (falls back to `"Your Address Here"` if unset). Pass a string or content to override. |
 | `recipient-name` | str | `"Company Name Here"` | The recipient's name or company displayed in the header. |
 | `recipient-address` | str | `"Company Address Here"` | The recipient's mailing address displayed in the header. Supports multiline content. |
 | `date` | str | `datetime.today().display()` | The date displayed in the letter header. Defaults to today's date. |

--- a/docs/web/docs/api-reference.md
+++ b/docs/web/docs/api-reference.md
@@ -23,12 +23,13 @@ Render a cover letter document with header, footer, and page layout applied.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `doc` | content | — | The body content of the letter. |
-| `sender-address` | str | `"Your Address Here"` | The sender's mailing address displayed in the header. |
+| `sender-address` | str \| auto | `auto` | The sender's mailing address. Defaults to `auto`, which reads from `metadata.personal.address`. Pass a string or content to override. |
 | `recipient-name` | str | `"Company Name Here"` | The recipient's name or company displayed in the header. |
-| `recipient-address` | str | `"Company Address Here"` | The recipient's mailing address displayed in the header. |
+| `recipient-address` | str | `"Company Address Here"` | The recipient's mailing address displayed in the header. Supports multiline content. |
 | `date` | str | `datetime.today().display()` | The date displayed in the letter header. Defaults to today's date. |
 | `subject` | str | `"Subject: Hey!"` | The subject line of the letter. |
 | `signature` | str \| content | `""` | (optional) path to a signature image, or content to display as signature. |
+| `address-style` | str | `"smallcaps"` | Address rendering style. `"smallcaps"` (default) or `"normal"`. |
 
 ---
 

--- a/docs/web/docs/components.md
+++ b/docs/web/docs/components.md
@@ -2,6 +2,38 @@
 
 These are the building blocks of your CV. For full parameter details, see the [API Reference](api-reference.md).
 
+## Entry Point Functions
+
+### cv
+
+```typ
+#show: cv.with(
+  metadata,
+  profile-photo: image("assets/avatar.png"),
+)
+```
+
+The `cv()` function is the main entry point that sets up page layout, fonts, header, and footer. All CV modules are rendered inside its body.
+
+### letter
+
+```typ
+#show: letter.with(
+  metadata,
+  sender-address: "123 Main St, City, State 12345",
+  recipient-name: "ABC Company",
+  recipient-address: "456 Business Ave, City, State 67890",
+  subject: "Application for Data Analyst Position",
+  signature: image("assets/signature.png"),
+)
+```
+
+The `letter()` function sets up the cover letter layout. `sender-address` defaults to `auto`, which reads from `metadata.personal.address` in `metadata.toml`. Use `address-style: "normal"` to disable smallcaps on addresses.
+
+---
+
+## CV Components
+
 ## cv-section
 
 ```typ

--- a/docs/web/docs/components.md
+++ b/docs/web/docs/components.md
@@ -28,7 +28,7 @@ The `cv()` function is the main entry point that sets up page layout, fonts, hea
 )
 ```
 
-The `letter()` function sets up the cover letter layout. `sender-address` defaults to `auto`, which reads from `metadata.personal.address` in `metadata.toml`. Use `address-style: "normal"` to disable smallcaps on addresses.
+The `letter()` function sets up the cover letter layout. `sender-address` defaults to `auto`, which reads from `metadata.personal.address` in `metadata.toml` (falls back to `"Your Address Here"` if unset). Use `address-style: "normal"` to disable smallcaps on addresses.
 
 ---
 

--- a/docs/web/docs/configuration.md
+++ b/docs/web/docs/configuration.md
@@ -84,6 +84,8 @@ language = "en"
     first_name = "John"
     # Your last name, displayed in the header
     last_name = "Doe"
+    # Your mailing address, used as default sender-address in the cover letter
+    # address = "123 Main St, San Francisco, CA 94102"
 
     # The order of entries below controls the display order of icons/links in the header
     # The custom value is for any additional information you want to add, name it as custom-1, custom-2, etc.
@@ -229,6 +231,7 @@ language = "en"
 |-----|------|---------|-------------|
 | `first_name` | string | `"John"` | Your first name, displayed in the header |
 | `last_name` | string | `"Doe"` | Your last name, displayed in the header |
+| `address` | string | — | *(optional)* Your mailing address, used as default sender-address in the cover letter |
 
 ### `[personal.info]`
 

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -74,7 +74,7 @@
 ///
 /// - metadata (dictionary): The metadata dictionary read from `metadata.toml`.
 /// - doc (content): The body content of the letter.
-/// - sender-address (str | auto): The sender's mailing address. Defaults to `auto`, which reads from `metadata.personal.address`. Pass a string or content to override.
+/// - sender-address (str | auto): The sender's mailing address. Defaults to `auto`, which reads from `metadata.personal.address` (falls back to `"Your Address Here"` if unset). Pass a string or content to override.
 /// - recipient-name (str): The recipient's name or company displayed in the header.
 /// - recipient-address (str): The recipient's mailing address displayed in the header. Supports multiline content.
 /// - date (str): The date displayed in the letter header. Defaults to today's date.


### PR DESCRIPTION
## Summary

- Add example sections for `cv()` and `letter()` in `components.md` — these were the only two public functions without examples (closes #167)
- Re-generate `api-reference.md` to reflect PR #164 changes: `sender-address` type updated to `str | auto` with correct default, new `address-style` parameter documented (closes #168)
- Re-generate `configuration.md` to include the `personal.address` field

## Test plan

- [x] Verify MkDocs site builds without errors (`mkdocs build --strict` passes)
- [x] Check `components.md` renders cv/letter examples correctly ("Entry Point Functions" section present)
- [x] Check `api-reference.md` shows updated letter() signature (`sender-address` with `auto` type, `address-style` parameter)
- [x] Check `configuration.md` includes `personal.address` field (in both example and key reference table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)