### PR TITLE
fix(api): kebab-case cv-section param + absolute README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Full guide, component gallery, recipes, and configuration reference → **[brill
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+Contributions are welcome! See [CONTRIBUTING.md](https://github.com/yunanwg/brilliant-CV/blob/main/CONTRIBUTING.md) for guidelines.
 
 ## Sponsors
 

--- a/docs/pdf/docs.typ
+++ b/docs/pdf/docs.typ
@@ -111,11 +111,11 @@ These are the building blocks of your CV.
 ```typ
 #cv-section("Professional Experience")              // uses [layout.section] defaults
 #cv-section("Skills", highlight: "none")            // no highlight
-#cv-section("Education", highlight_letters: 5)      // first 5 chars in accent
+#cv-section("Education", highlight-letters: 5)      // first 5 chars in accent
 #cv-section("教育背景", highlight: "full")          // entire title in accent (CJK convention)
 ```
 
-Highlight modes are controlled globally by `[layout.section] title_highlight` (`"first-letters"` default, `"full"`, or `"none"`) and the per-call `highlight:` / `highlight_letters:` parameters override on a single section.
+Highlight modes are controlled globally by `[layout.section] title_highlight` (`"first-letters"` default, `"full"`, or `"none"`) and the per-call `highlight:` / `highlight-letters:` parameters override on a single section.
 
 === cv-entry
 

--- a/docs/web/docs/api-reference.md
+++ b/docs/web/docs/api-reference.md
@@ -50,7 +50,7 @@ profile metadata. Three modes are supported:
   unnatural.
 - `"none"`: the entire title is rendered in black, no accent highlighting.
 
-Per-section overrides: pass `highlight` and/or `highlight_letters` to
+Per-section overrides: pass `highlight` and/or `highlight-letters` to
 override the metadata defaults for a single section.
 
   Accepts `"first-letters"`, `"full"`, or `"none"`.
@@ -59,7 +59,7 @@ override the metadata defaults for a single section.
 |-----------|------|---------|-------------|
 | `title` | str | — | The title of the section. |
 | `highlight` | str | `none` | (optional) override `[layout.section].title_highlight`. |
-| `highlight_letters` | int | `none` | (optional) override `[layout.section].title_highlight_letters`. |
+| `highlight-letters` | int | `none` | (optional) override `[layout.section].title_highlight_letters`. |
 | `color` | color | `none` | (optional) override the accent color for this section. |
 
 ```typ

--- a/docs/web/docs/components.md
+++ b/docs/web/docs/components.md
@@ -42,7 +42,7 @@ The `cv()` function is the main entry point. It runs schema-migration guards (pa
 
 ![cv-section first-letters mode](assets/components/cv-section-first-letters.png)
 
-The default `[layout.section] title_highlight = "first-letters"` highlights the leading 3 chars in the accent color (Latin convention). Override per call with `highlight:` (`"first-letters"` / `"full"` / `"none"`) and `highlight_letters:` (int).
+The default `[layout.section] title_highlight = "first-letters"` highlights the leading 3 chars in the accent color (Latin convention). Override per call with `highlight:` (`"first-letters"` / `"full"` / `"none"`) and `highlight-letters:` (int).
 
 ```typ
 #cv-section("教育背景", highlight: "full")
@@ -61,12 +61,12 @@ The default `[layout.section] title_highlight = "first-letters"` highlights the 
 `"none"` keeps the title in body text color — useful for muted, all-monochrome layouts.
 
 ```typ
-#cv-section("Professional Experience", highlight_letters: 5)
+#cv-section("Professional Experience", highlight-letters: 5)
 ```
 
 ![cv-section 5-letter custom highlight](assets/components/cv-section-custom-letters.png)
 
-`highlight_letters` overrides the default of 3 — handy for short multi-word titles.
+`highlight-letters` overrides the default of 3 — handy for short multi-word titles.
 
 ---
 

--- a/src/cv.typ
+++ b/src/cv.typ
@@ -340,13 +340,13 @@
 ///   unnatural.
 /// - `"none"`: the entire title is rendered in black, no accent highlighting.
 ///
-/// Per-section overrides: pass `highlight` and/or `highlight_letters` to
+/// Per-section overrides: pass `highlight` and/or `highlight-letters` to
 /// override the metadata defaults for a single section.
 ///
 /// - title (str): The title of the section.
 /// - highlight (str): (optional) override `[layout.section].title_highlight`.
 ///   Accepts `"first-letters"`, `"full"`, or `"none"`.
-/// - highlight_letters (int): (optional) override `[layout.section].title_highlight_letters`.
+/// - highlight-letters (int): (optional) override `[layout.section].title_highlight_letters`.
 /// - color (color): (optional) override the accent color for this section.
 /// - metadata (dictionary): (optional) the metadata read from the TOML file.
 /// - awesome-colors (array): (optional) the awesome colors of the CV.
@@ -361,7 +361,7 @@
 #let cv-section(
   title,
   highlight: none,
-  highlight_letters: none,
+  highlight-letters: none,
   color: none,
   metadata: none,
   awesome-colors: _awesome-colors,
@@ -374,8 +374,8 @@
   } else {
     section-cfg.at("title_highlight", default: "first-letters")
   }
-  let letters = if highlight_letters != none {
-    highlight_letters
+  let letters = if highlight-letters != none {
+    highlight-letters
   } else {
     section-cfg.at("title_highlight_letters", default: 3)
   }


### PR DESCRIPTION
## Summary

Two lint fixes flagged by `typst-package-check` on the upstream `brilliant-cv:4.0.0` PR ([typst/packages#4739](https://github.com/typst/packages/pull/4739), closed in favor of v4.0.1):

1. **`README.md:52`** linked to a relative `CONTRIBUTING.md` that doesn't exist in the published Universe payload (`CONTRIBUTING.md` is intentionally `exclude`d in `typst.toml` — contributor-facing, not consumer-facing). Changed to absolute GitHub URL.
2. **`src/cv.typ:364`** — `cv-section`'s `highlight_letters` parameter was the lone snake_case name in the public API; everything else is kebab-case. Renamed to `highlight-letters`. The matching TOML key (`title_highlight_letters` in `[layout.section]`) stays snake_case — TOML keys aren't governed by Typst's kebab-case convention.

## Breaking change disclosure

Tiny: anyone calling `cv-section(..., highlight_letters: 5)` directly will need to switch to `highlight-letters`. The override path isn't documented in any profile template, almost everyone configures via TOML, and v4.0 was tagged 3 days ago. Worth doing now while the surface is fresh.

## Test plan

- [x] `just test` — 32/32 tytanic + 10/10 panic, all pass
- [x] `just fmt-check` passes
- [x] `just docs-generate` regenerated `api-reference.md` to match new doc comments

No regression test added: this is API surface cleanup, not a behavior fix. Typst's argument validation rejects the old name at compile time, which is its own guard.

## Follow-up

Once merged: bump `typst.toml` to `4.0.1`, run `just release 4.0.1`, fresh PR to `typst/packages` for v4.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)