### PR TITLE
docs: document Font Awesome setup for Typst Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
 typst init @preview/brilliant-cv
 ```
 
+Using Typst Web? Upload the Font Awesome 7 Free desktop OTF files (Regular,
+Solid, and Brands) to your project so the contact icons render correctly.
+
 Edit `profile_en/metadata.toml` and the content modules in `profile_en/*.typ` — it's the most heavily annotated profile. To add a new variant, copy the directory and tweak the fields that differ.
 
 ```bash

--- a/docs/web/docs/getting-started.md
+++ b/docs/web/docs/getting-started.md
@@ -20,6 +20,11 @@ In order to make Typst render correctly, you will have to install the required f
 
 - [Roboto](https://fonts.google.com/specimen/Roboto)
 - [Source Sans 3](https://fonts.google.com/specimen/Source+Sans+3) (or Source Sans Pro)
+- [Font Awesome 7 Free desktop fonts](https://fontawesome.com/download) (Regular, Solid, and Brands OTF files)
+
+For Typst Web, upload the three Font Awesome OTF files to your project. For
+local compilation, install them on your operating system. Without these fonts,
+contact icons render as boxes.
 
 ## Step 3: File Structure Map
 

--- a/docs/web/docs/troubleshooting.md
+++ b/docs/web/docs/troubleshooting.md
@@ -8,6 +8,17 @@ Paths in module files are relative to the module file itself, not the project ro
 
 Install Roboto and Source Sans 3 (or Source Sans Pro) locally. For non-Latin profiles, install the font(s) listed in `[layout.fonts] regular_fonts` and `[layout.fonts] header_font` for that profile (e.g. "Heiti SC" for Chinese on macOS, or "Noto Sans CJK SC" as a freely-redistributable alternative).
 
+## Icons Render as Boxes
+
+Contact icons use the Font Awesome desktop fonts. Download the
+[Font Awesome 7 Free desktop package](https://fontawesome.com/download), then:
+
+- In Typst Web, upload the Regular, Solid, and Brands OTF files to your project.
+- For local compilation, install the same OTF files on your operating system.
+
+Recompile after adding the fonts. The package provides the icon mappings, but
+does not bundle the font files themselves.
+
 ## h-bar() Not Working
 
 Make sure you import `h-bar` from the package:


### PR DESCRIPTION
## Summary

- list the Font Awesome 7 OTF files alongside the other required fonts
- explain how Typst Web users can make contact icons render correctly
- add a focused troubleshooting entry for icons shown as boxes

## Validation

- `just docs-build`

Closes #192
