### PR TITLE
fix: repair shipped-example rendering defects and broken default paths

### DIFF
--- a/src/cv.typ
+++ b/src/cv.typ
@@ -441,11 +441,11 @@
   let accent-color = _resolve-accent-color(color, awesome-colors, metadata)
   let before-entry-skip = eval(metadata.layout.at(
     "before_entry_skip",
-    default: 1pt,
+    default: "1pt",
   ))
   let before-entry-description-skip = eval(metadata.layout.at(
     "before_entry_description_skip",
-    default: 1pt,
+    default: "1pt",
   ))
   // Default date column width. Profiles whose locale needs more room
   // (zh, fr, it, ...) should set [layout] date_width explicitly.
@@ -693,7 +693,6 @@
         },
         (styles.b2)((styles.dates)(date)),
       )
-      (styles.description)(description)
       _create-entry-tag-list(tags, styles.tag)
     }
   }
@@ -1057,7 +1056,7 @@
 /// `key-list` are included, allowing selective publication lists.
 ///
 /// - bib (bibliography): The `bibliography` object with the path to the bib file.
-/// - key-list (list): The list of bib keys to include when `ref-full` is `false`.
+/// - key-list (array): The array of bib keys to include when `ref-full` is `false`.
 /// - ref-style (str): The reference style of the publication list (e.g., `"apa"`).
 /// - ref-full (bool): Whether to show all entries (`true`) or only those in `key-list` (`false`).
 /// -> content
@@ -1065,7 +1064,7 @@
   bib: "",
   ref-style: "apa",
   ref-full: true,
-  key-list: list(),
+  key-list: (),
 ) = {
   let publication-style(str) = {
     text(str)

--- a/template/profile_de/education.typ
+++ b/template/profile_de/education.typ
@@ -19,7 +19,7 @@
 #cv-entry(
   title: [Bachelors of Science in Informatik],
   society: [Universität von Kalifornien, Los Angeles],
-  date: [2018 - 2020],
+  date: [2014 - 2018],
   location: [USA],
   logo: image("../assets/logos/ucla.png"),
   description: list(

--- a/template/profile_de/publications.typ
+++ b/template/profile_de/publications.typ
@@ -12,4 +12,5 @@
     "wilson2022",
   ),
   ref-style: "apa",
+  ref-full: false,
 )

--- a/template/profile_en/professional.typ
+++ b/template/profile_en/professional.typ
@@ -14,6 +14,7 @@
 
 #cv-entry-continued(
   title: [Director of Data Science],
+  date: [2020 - Present],
   description: list(
     [Lead a team of data scientists and analysts to develop and implement data-driven strategies, develop predictive models and algorithms to support decision-making across the organization],
     [Collaborate with executive leadership to identify business opportunities and drive growth, implement best practices for data governance, quality, and security],

--- a/template/profile_fr/publications.typ
+++ b/template/profile_fr/publications.typ
@@ -12,4 +12,5 @@
     "wilson2022",
   ),
   ref-style: "apa",
+  ref-full: false,
 )

--- a/template/profile_it/education.typ
+++ b/template/profile_it/education.typ
@@ -19,7 +19,7 @@
 #cv-entry(
   title: [Laurea in informatica],
   society: [Università della California, Los Angeles],
-  date: [2018 - 2020],
+  date: [2014 - 2018],
   location: [USA],
   logo: image("../assets/logos/ucla.png"),
   description: list(

--- a/template/profile_it/publications.typ
+++ b/template/profile_it/publications.typ
@@ -12,4 +12,5 @@
     "wilson2022",
   ),
   ref-style: "apa",
+  ref-full: false,
 )

--- a/template/profile_zh/publications.typ
+++ b/template/profile_zh/publications.typ
@@ -12,4 +12,5 @@
     "wilson2022",
   ),
   ref-style: "apa",
+  ref-full: false,
 )

--- a/tests/components/cv-entry-continued-multiline-date/test.typ
+++ b/tests/components/cv-entry-continued-multiline-date/test.typ
@@ -1,0 +1,24 @@
+// Regression: in the multi-line-date branch of cv-entry-continued (a date
+// containing linebreak()), the description was rendered once inside the left
+// table cell AND unconditionally a second time after the table — the shipped
+// profile_en "Data Scientist" example printed both bullets twice. This pins
+// the layout: description exactly once, side by side with the stacked dates.
+
+#import "/src/cv.typ": cv-entry-continued, cv-metadata
+#import "/src/utils/styles.typ": _regular-colors
+#import "/tests/common.typ": minimal-metadata, test-font-list
+
+#set page(width: 16cm, height: auto, margin: 0.5cm)
+#set text(font: test-font-list, size: 9pt, fill: _regular-colors.lightgray)
+
+#cv-metadata.update(_ => minimal-metadata)
+
+#cv-entry-continued(
+  title: [Data Scientist],
+  date: [2017 - 2020 #linebreak() 2021 - 2022],
+  description: list(
+    [Analyzed large datasets with SQL and Python.],
+    [Built dashboards and maintained data pipelines.],
+  ),
+  tags: ("SQL", "Python"),
+)

--- a/tests/units/cv-entry-default-skips/test.typ
+++ b/tests/units/cv-entry-default-skips/test.typ
@@ -1,0 +1,24 @@
+// Regression: before_entry_skip / before_entry_description_skip defaults were
+// length literals (1pt) passed to the string-only eval(), so OMITTING either
+// key crashed instead of falling back to 1pt. All shipped profiles set both
+// keys, which is why the broken fallback went unnoticed. This fixture drops
+// both keys and must still compile.
+
+#import "/src/cv.typ": cv-entry, cv-metadata
+#import "/tests/common.typ": minimal-metadata
+
+#let md = {
+  let m = minimal-metadata
+  let _ = m.layout.remove("before_entry_skip")
+  let _ = m.layout.remove("before_entry_description_skip")
+  m
+}
+#cv-metadata.update(_ => md)
+
+#cv-entry(
+  title: [Maintainer],
+  society: [github.com/acme/widget],
+  date: [2020 - 2024],
+  location: [Open Source],
+  description: list([A small utility library.]),
+)

--- a/tests/units/cv-publication-default-keylist/pubs.bib
+++ b/tests/units/cv-publication-default-keylist/pubs.bib
@@ -1,0 +1,13 @@
+@article{doe2023,
+  author = {Doe, Jane},
+  title = {A Minimal Fixture Entry},
+  journal = {Journal of Test Fixtures},
+  year = {2023},
+}
+
+@article{roe2024,
+  author = {Roe, Richard},
+  title = {A Second Fixture Entry},
+  journal = {Journal of Test Fixtures},
+  year = {2024},
+}

--- a/tests/units/cv-publication-default-keylist/test.typ
+++ b/tests/units/cv-publication-default-keylist/test.typ
@@ -1,0 +1,12 @@
+// Regression: key-list's default was `list()` — a content element, not an
+// array — so `cv-publication(ref-full: false)` without an explicit key-list
+// crashed with "cannot loop over content". The default is now `()`; selecting
+// nothing must compile (and render an empty publication list).
+
+#import "/src/cv.typ": cv-publication
+
+#cv-publication(
+  bib: bibliography("pubs.bib"),
+  ref-style: "ieee",
+  ref-full: false,
+)


### PR DESCRIPTION
Five confirmed defects, all hidden by the fact that every shipped profile sets every optional key (so fallback paths never ran) or by translation-pass drift:

**src/cv.typ**
- `before_entry_skip` / `before_entry_description_skip` defaults were length literals passed to the string-only `eval()` — omitting either key crashed with `expected string, found length` instead of defaulting to 1pt
- `cv-publication`'s `key-list` default was `list()` (a content element); `ref-full: false` without an explicit key-list crashed with `cannot loop over content`
- `cv-entry-continued` rendered the description **twice** in the multi-line-date branch — visible verbatim duplication in profile_en's own "Data Scientist" example

**template/**
- profile_en's Director entry lacked `date:`, rendering the literal placeholder **"Date"** in the flagship example PDF
- fr/de/it/zh `publications.typ` passed `key-list` without `ref-full: false`, so the filter was silently ignored and a fourth, undeclared reference rendered
- de/it Bachelor entries copy-pasted the Master's dates

**Verification**: both new unit tests fail against the previous src (`expected string, found length` / `cannot loop over content`) and pass now; compiled old-vs-new profile_en PDFs show the duplicated bullets dropping 3→2 and `Date` → `2020 - Present`. All five profiles + letter compile.

> [!IMPORTANT]
> **CI will be red until refs are regenerated**: run `just test-update` on an arm64 machine and commit — profile regression refs change (duplicate text disappears, dates fixed), and the new component fixture `cv-entry-continued-multiline-date` needs its first ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVqmjueMxXJSNZQJZdZE6x

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVqmjueMxXJSNZQJZdZE6x)_