### PR TITLE
docs: ship font/privacy guidance with typst init + Chinese quickstart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ For running the test suite locally:
 
 Optional but helpful:
 
-- `pre-commit`, `typos` (recommended tools already mentioned in the README)
+- `pre-commit`, `typos` (recommended tools already covered in [Getting Started → Step 8](docs/web/docs/getting-started.md))
 
 ---
 

--- a/docs/web/docs/getting-started.md
+++ b/docs/web/docs/getting-started.md
@@ -42,6 +42,13 @@ After bootstrapping, your project will contain these files:
 !!! tip
     Don't edit the package source files under `@preview/brilliant-cv` — they are managed by the Typst package manager.
 
+!!! warning "Keep personal files out of public repos"
+    Many people track their filled-in CV project in a public git repo (see
+    Step 8). Your `assets/` folder ends up holding a real profile photo and,
+    if you use `letter.typ`, a scanned signature — both are sensitive.
+    Consider a private repo, or `.gitignore` the real files and commit
+    placeholders instead.
+
 ## Step 4: Configure profile_en/metadata.toml
 
 All customization for the English profile goes through `profile_en/metadata.toml` — it is a **complete, self-contained CV configuration**. See the [Configuration Reference](configuration.md) for the full set of fields.
@@ -94,3 +101,39 @@ It is recommended to:
 2. Use [`typstyle`](https://github.com/typstyle-rs/typstyle) and `pre-commit` to keep your `.typ` files consistently formatted.
 3. Use [`typos`](https://github.com/crate-ci/typos) to catch spelling mistakes if your CV is in English.
 4. Wire up CI to compile your CV on every push — see [Recipes → CI/CD with GitHub Actions](recipes.md#cicd-with-github-actions).
+
+## 中文快速上手 (Chinese quickstart)
+
+The template ships `profile_zh/` as a ready-made example — copy it, or copy
+`profile_en/` to `profile_zh/` and edit `metadata.toml`. v4 has no automatic
+"language" mode: fonts, name layout, section styling, and date column width
+are all set explicitly:
+
+```toml
+[personal]
+display_name = "王道尔"        # overrides the Latin first/last name split
+
+[layout]
+date_width = "4.7cm"          # wider column fits Chinese month/year strings
+
+[layout.fonts]
+regular_fonts = ["Source Sans 3", "Heiti SC"]  # Latin + CJK fallback chain
+header_font = "Heiti SC"
+
+[layout.section]
+title_highlight = "full"      # whole title in accent color, not split by codepoint
+```
+
+!!! tip
+    Heiti SC ships only with macOS — elsewhere (and on typst.app) it silently
+    falls back to a different font, changing the look. For cross-platform or
+    typst.app use, swap it for `"Noto Sans CJK SC"` in both font fields above
+    (install it locally, or upload it to your typst.app project).
+
+Compile with the profile flag:
+
+```bash
+typst compile cv.typ --input profile=zh
+```
+
+See [Troubleshooting → Non-Latin Characters](troubleshooting.md#non-latin-characters-showing-as-boxes) if characters render as boxes.

--- a/docs/web/docs/migration.md
+++ b/docs/web/docs/migration.md
@@ -164,7 +164,7 @@ The package entry point is unchanged, but you should update any version-pinned i
 
 ```typ
 // Before (v2)
-#import "@preview/brilliant-cv:4.0.1": *
+#import "@preview/brilliant-cv:2.3.0": *
 
 // After (v3)
 #import "@preview/brilliant-cv:4.0.1": *

--- a/template/cv.typ
+++ b/template/cv.typ
@@ -1,3 +1,12 @@
+// Required fonts: Roboto, Source Sans 3 (or Source Sans Pro), and the
+// Font Awesome 7 Free desktop OTFs (Regular, Solid, Brands) — get them from
+// https://fonts.google.com/specimen/Roboto,
+// https://fonts.google.com/specimen/Source+Sans+3, and
+// https://fontawesome.com/download. Install locally for desktop Typst.
+// On typst.app, the web app does not bundle Font Awesome — upload the three
+// .otf files to your project instead, or contact icons render as boxes.
+// See https://yunanwg.github.io/brilliant-CV/ (Troubleshooting) for details.
+
 // Imports
 #import "@preview/brilliant-cv:4.0.1": cv, h-bar
 
@@ -17,6 +26,7 @@
 
 #show: cv.with(
   metadata,
+  // Profile photos are personal and sensitive — avoid committing real ones to public git repos.
   profile-photo: image("assets/avatar.png"),
   // Replace the generated contact row with arbitrary Typst content:
   // header-info: [

--- a/template/letter.typ
+++ b/template/letter.typ
@@ -1,3 +1,12 @@
+// Required fonts: Roboto, Source Sans 3 (or Source Sans Pro), and the
+// Font Awesome 7 Free desktop OTFs (Regular, Solid, Brands) — get them from
+// https://fonts.google.com/specimen/Roboto,
+// https://fonts.google.com/specimen/Source+Sans+3, and
+// https://fontawesome.com/download. Install locally for desktop Typst.
+// On typst.app, the web app does not bundle Font Awesome — upload the three
+// .otf files to your project instead, or contact icons render as boxes.
+// See https://yunanwg.github.io/brilliant-CV/ (Troubleshooting) for details.
+
 // Imports
 #import "@preview/brilliant-cv:4.0.1": letter
 
@@ -18,6 +27,7 @@
   // date defaults to today; pass a string to override:
   date: datetime.today().display(),
   subject: "Subject: Hey!",
+  // Scanned signatures are personal and sensitive — avoid committing real ones to public git repos.
   signature: image("assets/signature.png"),
   // address-style: "normal",  // use "normal" to disable smallcaps on addresses
 )

--- a/template/profile_zh/metadata.toml
+++ b/template/profile_zh/metadata.toml
@@ -19,6 +19,13 @@ letter_footer = "申请信"
     [layout.fonts]
         # Mixed Source Sans 3 + Heiti SC. Typst's codepoint-level fallback
         # picks Heiti SC for CJK characters and Source Sans 3 for Latin.
+        # Heiti SC ships only with macOS — on other platforms (and on
+        # typst.app) it silently falls back to a different font, changing
+        # the look. Cross-platform/typst.app users should use
+        # "Noto Sans CJK SC" instead (install it locally, or upload it to
+        # your typst.app project), e.g.:
+        #   regular_fonts = ["Source Sans 3", "Noto Sans CJK SC"]
+        #   header_font = "Noto Sans CJK SC"
         regular_fonts = ["Source Sans 3", "Heiti SC"]
         header_font = "Heiti SC"
 


### PR DESCRIPTION
`typst init @preview/brilliant-cv` delivers only `template/` — README and the docs site never reach those users, which is why Font-Awesome-icons-render-as-boxes keeps being re-reported across years (#11, #31, #57, #192). All changes are comments/docs only; zero rendering impact (verified: every changed `.typ`/`.toml` line is a comment).

- comment block at the top of `template/cv.typ` + `letter.typ`: required fonts (Roboto, Source Sans 3, Font Awesome 7 Free OTFs), the typst.app upload note, troubleshooting link
- inline note in `profile_zh/metadata.toml`: Heiti SC is macOS-only and falls back silently elsewhere; Noto Sans CJK SC is the cross-platform alternative
- privacy notes near `profile-photo:`/`signature:` and in getting-started: keep real photos/signatures out of public repos
- getting-started gains a compact 中文快速上手 section (reusing the zh worked example that already existed in migration.md)
- fixed CONTRIBUTING's false "mentioned in the README" pointer and migration.md's v2 example that showed identical before/after imports

`mkdocs build --strict` passes (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVqmjueMxXJSNZQJZdZE6x

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVqmjueMxXJSNZQJZdZE6x)_