### PR TITLE
feat(inject)!: make ATS keyword injection opt-in with honest framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ## ✨ Key Features
 
 - **Profile-based variants** — Each `profile_<name>/` is a complete, self-contained CV. Switch with `--input profile=fr` at compile time. No language whitelist; any script (CJK, Arabic, Hebrew, …) is configurable via `[layout.fonts]`.
-- **AI & ATS friendly** — Keyword injection helps your CV pass automated screening systems.
+- **Optional ATS keyword injection** — Opt-in hidden keyword text for automated screeners, marked as a PDF artifact so screen readers skip it. Off by default: some screening systems detect and penalize hidden text, so read the notes in `metadata.toml` before enabling, and keep keywords truthful.
 - **Pixel-perfect tested** — 40+ tests run inside a Linux Docker baseline; layout regressions can't slip past CI.
 
 ## Quick Start

--- a/docs/web/docs/index.md
+++ b/docs/web/docs/index.md
@@ -15,7 +15,7 @@ A modern, modular, and feature-rich CV template for [Typst](https://typst.app).
 
 - **Separation of Style & Content** — Write your CV entries in simple Typst files; the template handles layout and styling.
 - **Profile-based Variants** — Each `profile_<name>/` is a complete, self-contained CV. Switch with `--input profile=fr` at compile time. No language whitelist; any script (CJK, Arabic, Hebrew, …) is configurable explicitly via `[layout.fonts]`.
-- **AI & ATS Friendly** — Unique "keyword injection" feature to help your CV pass automated screening systems.
+- **Optional ATS Keyword Injection** — Opt-in hidden keyword text for automated screeners, marked as a PDF artifact so screen readers skip it. Off by default — some screening systems detect and penalize hidden text; see the `[inject]` notes in `metadata.toml` before enabling.
 - **Highly Customizable** — Tweak colors, fonts, layout, and section highlights via per-profile `metadata.toml` files.
 - **Pixel-perfect Tested** — 40+ tests (panic, unit, component, regression) run inside a Linux Docker baseline so refs are deterministic. Layout regressions can't slip past CI.
 - **Zero-Setup** — Get started in seconds with the Typst CLI.

--- a/src/utils/injection.typ
+++ b/src/utils/injection.typ
@@ -2,6 +2,14 @@
 A module containing the injection logic for the AI prompt and keywords.
 */
 
+/// Place hidden ATS/LLM-screener text into the document.
+///
+/// The text renders as 2pt white and is wrapped in `pdf.artifact` (Typst
+/// 0.14+) so assistive technology skips it, while plain-text extraction —
+/// what ATS pipelines read — still sees it. Note the text remains
+/// extractable via copy/paste, and some screeners actively detect hidden
+/// text; the template ships with injection disabled by default.
+/// Emits nothing when there is nothing to inject.
 #let _inject(
   custom-ai-prompt-text: none,
   keywords: (),
@@ -16,5 +24,13 @@ A module containing the injection logic for the AI prompt and keywords.
     parts.push(keywords.join(" "))
   }
 
-  place(text(parts.join(" "), size: 2pt, fill: white), dx: 0%, dy: 0%)
+  if parts.len() == 0 {
+    return
+  }
+
+  place(
+    pdf.artifact(text(parts.join(" "), size: 2pt, fill: white)),
+    dx: 0%,
+    dy: 0%,
+  )
 }

--- a/template/profile_de/metadata.toml
+++ b/template/profile_de/metadata.toml
@@ -38,7 +38,10 @@ letter_footer = "Anschreiben"
 
 
 [inject]
-    injected_keywords_list = ["Datenanalyst", "GCP", "Python", "SQL", "Tableau"]
+    # OPT-IN: hidden ATS keyword text — disabled by default. See
+    # profile_en/metadata.toml for the trade-offs (some screening systems
+    # detect hidden text and may penalize it; keep keywords truthful).
+    # injected_keywords_list = ["Datenanalyst", "GCP", "Python", "SQL", "Tableau"]
 
 [personal]
     first_name = "John"

--- a/template/profile_en/metadata.toml
+++ b/template/profile_en/metadata.toml
@@ -84,11 +84,20 @@ letter_footer = "Cover letter"
 
 
 [inject]
-    # Hidden text injected into the PDF for ATS keyword matching (invisible to readers)
-    # custom_ai_prompt_text = "Custom prompt text here..."  # Uncomment to add a custom ATS prompt string
+    # OPT-IN: hidden keyword text (2pt, white) placed in the PDF so automated
+    # screening systems (ATS) that match keywords can pick it up. Disabled by
+    # default — uncomment to enable, and weigh the trade-offs first:
+    #   - Some ATS vendors and recruiters actively detect hidden text and may
+    #     treat it as manipulation, up to rejecting the application outright.
+    #   - The text stays extractable: copy/paste or "select all" reveals it.
+    #     (It is marked as a PDF artifact, so screen readers skip it.)
+    #   - Keep any keywords truthful to skills you actually have.
+    # injected_keywords_list = ["Data Analyst", "GCP", "Python", "SQL", "Tableau"]
 
-    # Hidden keywords injected into PDF metadata for ATS keyword matching (invisible to readers)
-    injected_keywords_list = ["Data Analyst", "GCP", "Python", "SQL", "Tableau"]
+    # Optional free-form hidden prompt aimed at LLM-based screeners. Same
+    # detection risks as above, and modern models largely ignore injected
+    # instructions — treat as experimental.
+    # custom_ai_prompt_text = "Custom prompt text here..."
 
 [personal]
     # Your first name, displayed in the header

--- a/template/profile_fr/metadata.toml
+++ b/template/profile_fr/metadata.toml
@@ -38,7 +38,10 @@ letter_footer = "Lettre de motivation"
 
 
 [inject]
-    injected_keywords_list = ["Analyste de Données", "GCP", "Python", "SQL", "Tableau"]
+    # OPT-IN: hidden ATS keyword text — disabled by default. See
+    # profile_en/metadata.toml for the trade-offs (some screening systems
+    # detect hidden text and may penalize it; keep keywords truthful).
+    # injected_keywords_list = ["Analyste de Données", "GCP", "Python", "SQL", "Tableau"]
 
 [personal]
     first_name = "John"

--- a/template/profile_it/metadata.toml
+++ b/template/profile_it/metadata.toml
@@ -38,7 +38,10 @@ letter_footer = "Lettera di presentazione"
 
 
 [inject]
-    injected_keywords_list = ["Analista di Dati", "GCP", "Python", "SQL", "Tableau"]
+    # OPT-IN: hidden ATS keyword text — disabled by default. See
+    # profile_en/metadata.toml for the trade-offs (some screening systems
+    # detect hidden text and may penalize it; keep keywords truthful).
+    # injected_keywords_list = ["Analista di Dati", "GCP", "Python", "SQL", "Tableau"]
 
 [personal]
     first_name = "John"

--- a/template/profile_zh/metadata.toml
+++ b/template/profile_zh/metadata.toml
@@ -44,7 +44,10 @@ letter_footer = "申请信"
 
 
 [inject]
-    injected_keywords_list = ["数据分析师", "GCP", "Python", "SQL", "Tableau"]
+    # OPT-IN（默认关闭）：隐藏的 ATS 关键词文本。部分简历筛选系统会主动检测
+    # 隐藏文字并可能因此扣分或拒绝；启用前请阅读 profile_en/metadata.toml
+    # 中的完整说明，且关键词应与真实技能相符。
+    # injected_keywords_list = ["数据分析师", "GCP", "Python", "SQL", "Tableau"]
 
 [personal]
     first_name = "John"


### PR DESCRIPTION
The `[inject]` feature shipped enabled in all five profiles and was marketed as "helps your CV pass automated screening systems" with no mention of risk — while screening vendors increasingly detect hidden resume text, and the hidden 2pt white string was announced by screen readers. Decision adopted: **keep the feature, make it honest**.

- all five profiles now ship `injected_keywords_list` commented out (**opt-in**), with trade-off notes in the metadata comments: detection risk, copy/paste extractability, keep-keywords-truthful (the en comments flow into the generated configuration docs)
- `_inject` wraps the hidden text in `pdf.artifact` (Typst 0.14+): plain-text extraction still sees the keywords — verified via `pdftotext` — but assistive technology now skips them
- `_inject` emits nothing when there's nothing to inject (was emitting an empty `place()`)
- README and docs index bullets reworded to an honest opt-in description

**BREAKING**: new projects generated from the template no longer inject keywords by default; existing users' `metadata.toml` files are unaffected.

Verification: all 5 profiles + letter compile; all three inject unit tests pass; the letter's extracted text layer no longer contains the keyword string by default; with keywords manually enabled, `pdftotext` still extracts them through the artifact marking. Visual refs should be unchanged (removed text was white-on-white) — please confirm with `just test-update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVqmjueMxXJSNZQJZdZE6x

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVqmjueMxXJSNZQJZdZE6x)_