### PR TITLE
ci: make release contract fail closed

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -1,62 +1,50 @@
 name: Compile Test
+
 permissions:
   contents: read
 
 on:
-    push:
-      branches: [main]
-    pull_request:
-    workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  CHECKOUT_PATH: ./project
-
 jobs:
-    compile:
-        runs-on: ubuntu-latest
-        strategy:
-          matrix:
-            # 0.14.0 proves the declared compiler floor in typst.toml;
-            # 0.15.1 matches the pinned test toolchain (tests/Dockerfile).
-            typst-version: ['0.14.0', '0.15.1']
-        steps:
-            - uses: actions/checkout@v7
-              with:
-                path: ${{ env.CHECKOUT_PATH }}
+  compile:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 0.14.0 proves the declared compiler floor in typst.toml;
+        # 0.15.1 matches the pinned test toolchain (tests/Dockerfile).
+        typst-version: ['0.14.0', '0.15.1']
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
-            - uses: SebRollen/toml-action@v1.2.0
-              id: get-package-name
-              with:
-                file: ./${{ env.CHECKOUT_PATH }}/typst.toml
-                field: package.name
+      - uses: typst-community/setup-typst@v5
+        with:
+          typst-version: ${{ matrix.typst-version }}
 
-            - uses: SebRollen/toml-action@v1.2.0
-              id: get-package-version
-              with:
-                file: ./${{ env.CHECKOUT_PATH }}/typst.toml
-                field: package.version
+      - name: Assemble exact package payload
+        run: python3 scripts/release_contract.py assemble "$RUNNER_TEMP/package"
 
-            - uses: SebRollen/toml-action@v1.2.0
-              id: get-template-path
-              with:
-                file: ./${{ env.CHECKOUT_PATH }}/typst.toml
-                field: template.path
+      - name: Fresh-init CV and letter for every profile
+        run: python3 scripts/release_contract.py smoke "$RUNNER_TEMP/package"
 
-            - uses: SebRollen/toml-action@v1.2.0
-              id: get-template-entrypoint
-              with:
-                file: ./${{ env.CHECKOUT_PATH }}/typst.toml
-                field: template.entrypoint
+  release-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
-            - uses: typst-community/setup-typst@v5
-              with:
-                typst-version: ${{ matrix.typst-version }}
-            - run: |
-                mkdir -p $HOME/.local/share/typst/packages/preview/${{ steps.get-package-name.outputs.value }}/${{ steps.get-package-version.outputs.value }}
-                cp -r -a ${{ env.CHECKOUT_PATH }}/. $HOME/.local/share/typst/packages/preview/${{ steps.get-package-name.outputs.value }}/${{ steps.get-package-version.outputs.value }}
-            - run: typst c ${{ env.CHECKOUT_PATH }}/${{ steps.get-template-path.outputs.value }}/${{ steps.get-template-entrypoint.outputs.value }}
-
+      - name: Check version and release-tool guards
+        run: |
+          python3 scripts/release_contract.py check-version
+          python3 scripts/test_release_contract.py

--- a/.github/workflows/release-and-publish.yaml
+++ b/.github/workflows/release-and-publish.yaml
@@ -4,276 +4,200 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version number (e.g., 4.0.0 or 4.0.0-test)'
-        required: true
-        type: string
-        
-permissions:
-  contents: write
-  pull-requests: write
-  actions: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  release-and-publish:
+  verify-contract:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Checkout current repository
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Extract and validate version
-        id: version
+      - name: Fetch the release branch boundary
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
+
+      - uses: astral-sh/setup-uv@v7
+
+      - uses: typst-community/setup-typst@v5
+        with:
+          typst-version: 0.15.1
+
+      - name: Verify immutable release ref
+        run: python3 scripts/release_contract.py check-release-ref "${{ github.ref_name }}"
+
+      - name: Test release guards
+        run: python3 scripts/test_release_contract.py
+
+      - name: Validate shipped metadata schema
+        run: uv run --quiet --with jsonschema==4.25.1 python scripts/check_metadata_schema.py
+
+      - name: Validate generated docs and public examples
         run: |
-          # Extract version from different trigger sources
-          if [ "${{ github.event_name }}" = "push" ] && [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            # Extract version from tag push (remove 'v' prefix if present)
-            VERSION="${{ github.ref_name }}"
-            VERSION=${VERSION#v}
-            echo "Version from tag push: $VERSION"
-          else
-            # Use manual input for workflow_dispatch
-            VERSION="${{ github.event.inputs.version }}"
-            if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
-              echo "⚠️ version input is empty, using default"
-              VERSION="4.0.0"
-            fi
-            echo "Version from manual input: $VERSION"
-          fi
-          
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
-          
-          # Validate version format (allow test suffix)
-          if ! echo "$VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-test)?$'; then
-            echo "❌ Invalid version format: $VERSION"
-            echo "Expected format: X.Y.Z or X.Y.Z-test (e.g., 2.0.7 or 2.0.7-test)"
-            exit 1
-          fi
-          echo "✅ Version format valid: $VERSION"
+          python3 scripts/release_contract.py check-generated-docs
+          python3 scripts/check_docs_snippets.py
 
-      - name: Update typst.toml version
+      - name: Assemble and smoke-test exact package payload
         run: |
-          # Create backup and update version
-          cp typst.toml typst.toml.backup
-          sed -i 's/^version = ".*"/version = "${{ steps.version.outputs.version }}"/' typst.toml
-          
-          echo "=== Updated typst.toml ==="
-          echo "Original version:"
-          grep '^version = ' typst.toml.backup
-          echo "New version:"
-          grep '^version = ' typst.toml
+          python3 scripts/release_contract.py assemble "$RUNNER_TEMP/package"
+          python3 scripts/release_contract.py smoke "$RUNNER_TEMP/package"
 
-      - name: Prepare package files
+      - name: Upload verified package payload
+        uses: actions/upload-artifact@v7
+        with:
+          name: package-payload
+          path: ${{ runner.temp }}/package/
+          if-no-files-found: error
+          retention-days: 7
+
+  verify-minimum-typst:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: typst-community/setup-typst@v5
+        with:
+          typst-version: 0.14.0
+
+      - name: Fresh-init every starter on the compiler floor
         run: |
-          # Create package directory structure
-          PACKAGE_DIR="packages/preview/brilliant-cv/${{ steps.version.outputs.version }}"
-          mkdir -p "$PACKAGE_DIR"
+          python3 scripts/release_contract.py assemble "$RUNNER_TEMP/package"
+          python3 scripts/release_contract.py smoke "$RUNNER_TEMP/package"
 
-          echo "=== Preparing package files ==="
-          echo "Target directory: $PACKAGE_DIR"
+  verify-tests:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
-          # Drive rsync's exclude list from typst.toml's [package].exclude
-          # so the manifest is the single source of truth for what ships
-          # to Universe. Adding a new exclude in typst.toml automatically
-          # takes effect here — no second hard-coded list to keep in sync.
-          MANIFEST_EXCLUDES=$(python3 -c '
-          import tomllib
-          with open("typst.toml", "rb") as f:
-              cfg = tomllib.load(f)
-          for item in cfg["package"].get("exclude", []):
-              print(f"--exclude={item}")
-          ')
+      - uses: docker/setup-buildx-action@v3
 
-          # Always-exclude set for workflow-runtime artifacts that
-          # shouldn't ship and aren't appropriate to list in typst.toml.
-          RUNTIME_EXCLUDES=(
-            --exclude=.git
-            --exclude=packages
-            --exclude=typst.toml.backup
-          )
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: tests/Dockerfile
+          tags: brilliant-cv-test
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-          echo "=== Manifest excludes (from typst.toml) ==="
-          echo "$MANIFEST_EXCLUDES"
+      - name: Run all tests and formatting checks
+        run: |
+          bash tests/guards.sh
+          docker run --rm \
+            -v "$PWD:/workspace" \
+            brilliant-cv-test \
+            bash -c "tt run --no-fail-fast && bash tests/panics/run.sh && typstyle --check src template tests"
 
-          # shellcheck disable=SC2086
-          rsync -av $MANIFEST_EXCLUDES "${RUNTIME_EXCLUDES[@]}" . "$PACKAGE_DIR/"
+  publish:
+    needs: [verify-contract, verify-minimum-typst, verify-tests]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
-          echo "=== Package structure ==="
-          find "$PACKAGE_DIR" -type f | sort
+      - uses: actions/download-artifact@v7
+        with:
+          name: package-payload
+          path: ${{ runner.temp }}/package
 
-          echo "=== Package typst.toml content ==="
-          cat "$PACKAGE_DIR/typst.toml"
+      - name: Recheck downloaded payload
+        run: python3 scripts/release_contract.py check-payload "$RUNNER_TEMP/package"
 
-          echo "=== Package size ==="
-          du -sh "$PACKAGE_DIR"
-
-          # Assert: no manifest-excluded path leaked into the prepared
-          # package. If any did, typst.toml claims something the release
-          # path didn't honor — exactly the drift this rewrite eliminates.
-          LEAKED=()
-          while IFS= read -r excluded; do
-              if [ -e "$PACKAGE_DIR/$excluded" ]; then
-                  LEAKED+=("$excluded")
-              fi
-          done < <(python3 -c '
-          import tomllib
-          with open("typst.toml", "rb") as f:
-              cfg = tomllib.load(f)
-          for item in cfg["package"].get("exclude", []):
-              print(item)
-          ')
-
-          if [ "${#LEAKED[@]}" -gt 0 ]; then
-              echo "❌ Manifest-excluded paths leaked into package:"
-              printf '   %s\n' "${LEAKED[@]}"
-              echo "Fix the rsync invocation above or remove the entries from typst.toml exclude."
-              exit 1
-          fi
-          echo "✅ All manifest-excluded paths verified absent from package"
-
-          # Validate required files exist
-          if [ ! -f "$PACKAGE_DIR/typst.toml" ]; then
-            echo "❌ Missing typst.toml in package"
-            exit 1
-          fi
-
-          if [ ! -f "$PACKAGE_DIR/src/lib.typ" ]; then
-            echo "❌ Missing src/lib.typ (entrypoint) in package"
-            exit 1
-          fi
-
-          echo "✅ Package validation passed"
-
-      - name: Create PR in upstream repository
-        if: ${{ !endsWith(steps.version.outputs.version, '-test') }}
+      - name: Open or update the Typst Universe submission
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.TYPST_PACKAGES_TOKEN || secrets.PAT_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+          PACKAGE_DIR: ${{ runner.temp }}/package
         run: |
-          echo "=== Creating PR in upstream repository ==="
-          
-          # Store the absolute path to the main workflow directory
-          MAIN_DIR="$(pwd)"
-          echo "Main workflow directory: $MAIN_DIR"
-          
-          # Set up git config and authentication first
+          set -euo pipefail
+          VERSION=${VERSION#v}
+          BRANCH="brilliant-cv-$VERSION"
+
+          if [ -z "$GH_TOKEN" ]; then
+            echo "TYPST_PACKAGES_TOKEN is required (PAT_TOKEN is a temporary fallback)."
+            exit 1
+          fi
+
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           gh auth setup-git
-          
-          # Clone your existing fork of the typst/packages repository
-          echo "=== Using existing fork: yunanwg/our-Typst-packages ==="
-          gh repo clone yunanwg/our-Typst-packages temp-fork
-          cd temp-fork
-          
-          # Add upstream remote (if it doesn't exist)
-          if ! git remote get-url upstream >/dev/null 2>&1; then
-            git remote add upstream https://github.com/typst/packages.git
-          fi
-          
-          # Fetch latest from upstream and sync fork
-          git fetch upstream
-          git checkout main
-          git reset --hard upstream/main
-          git push origin main --force
-          
-          # Create new branch for package submission (delete if exists)
-          BRANCH_NAME="brilliant-cv-${{ steps.version.outputs.version }}"
-          
-          # Delete branch if it exists (both local and remote)
-          if git show-ref --verify --quiet refs/heads/$BRANCH_NAME; then
-            echo "⚠️ Local branch $BRANCH_NAME exists, deleting..."
-            git branch -D $BRANCH_NAME
-          fi
-          
-          if git ls-remote --heads origin $BRANCH_NAME | grep -q $BRANCH_NAME; then
-            echo "⚠️ Remote branch $BRANCH_NAME exists, deleting..."
-            git push origin --delete $BRANCH_NAME
-          fi
-          
-          git checkout -b "$BRANCH_NAME"
-          
-          # Copy package files from the correct location
-          mkdir -p "packages/preview/brilliant-cv"
-          cp -r "$MAIN_DIR/packages/preview/brilliant-cv/${{ steps.version.outputs.version }}" "packages/preview/brilliant-cv/"
-          
-          # Commit changes
-          git add .
-          git commit -m "bump: brilliant-cv to v${{ steps.version.outputs.version }}
+          gh repo clone yunanwg/our-Typst-packages universe
+          cd universe
+          git remote add upstream https://github.com/typst/packages.git
+          git fetch --no-tags upstream main
 
-          Update brilliant-cv package to version ${{ steps.version.outputs.version }}"
-          
-          # Push branch to YOUR fork (auth already set up)
-          git push -u origin "$BRANCH_NAME"
-          
-          # Create PR from your fork to upstream
+          TARGET="packages/preview/brilliant-cv/$VERSION"
+          if git cat-file -e "upstream/main:$TARGET" 2>/dev/null; then
+            echo "$TARGET is already present on typst/packages main."
+            exit 0
+          fi
+
+          REMOTE_SHA=$(git ls-remote --heads origin "$BRANCH" | awk '{print $1}')
+          git switch --create "$BRANCH" upstream/main
+          mkdir -p "$TARGET"
+          cp -a "$PACKAGE_DIR/." "$TARGET/"
+          git add "$TARGET"
+          git commit -m "brilliant-cv:$VERSION"
+
+          if [ -n "$REMOTE_SHA" ]; then
+            git push \
+              --force-with-lease="refs/heads/$BRANCH:$REMOTE_SHA" \
+              origin "$BRANCH"
+          else
+            git push --set-upstream origin "$BRANCH"
+          fi
+
+          OPEN_PR=$(gh pr list \
+            --repo typst/packages \
+            --head "yunanwg:$BRANCH" \
+            --state open \
+            --json url \
+            --jq '.[0].url // ""')
+          if [ -n "$OPEN_PR" ]; then
+            echo "Reused existing submission: $OPEN_PR"
+            exit 0
+          fi
+
+          CLOSED_PR=$(gh pr list \
+            --repo typst/packages \
+            --head "yunanwg:$BRANCH" \
+            --state closed \
+            --json mergedAt,url \
+            --jq '[.[] | select(.mergedAt == null)][0].url // ""')
+          if [ -n "$CLOSED_PR" ]; then
+            echo "A closed, unmerged submission already exists: $CLOSED_PR"
+            exit 1
+          fi
+
           gh pr create \
             --repo typst/packages \
-            --title "brilliant-cv:${{ steps.version.outputs.version }}" \
-            --body "I am submitting
-          - [ ] a new package
-          - [X] an update for a package
-          
-          Description: This update brings brilliant-cv to version ${{ steps.version.outputs.version }}.
-          
-          I have read and followed the submission guidelines and, in particular, I
-          - [X] selected [a name](https://github.com/typst/packages/blob/main/docs/manifest.md#naming-rules) that isn't the most obvious or canonical name for what the package does
-          - [X] added a [\`typst.toml\`](https://github.com/typst/packages/blob/main/docs/manifest.md#package-metadata) file with all required keys
-          - [X] added a [\`README.md\`](https://github.com/typst/packages/blob/main/docs/documentation.md) with documentation for my package
-          - [X] have chosen [a license](https://github.com/typst/packages/blob/main/docs/licensing.md) and added a \`LICENSE\` file or linked one in my \`README.md\`
-          - [X] tested my package locally on my system and it worked
-          - [X] [\`exclude\`d](https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude) PDFs or README images, if any, but not the LICENSE
-          - [X] ensured that my package is licensed such that users can use and distribute the contents of its template directory without restriction, after modifying them through normal use." \
-            --head "yunanwg:$BRANCH_NAME" \
-            --base main
+            --head "yunanwg:$BRANCH" \
+            --base main \
+            --title "brilliant-cv:$VERSION" \
+            --body "Update brilliant-cv to $VERSION. The submitted directory is the exact payload validated from the immutable v$VERSION tag on Typst 0.14.0 and 0.15.1."
 
-          echo "✅ PR created successfully from fork to upstream repository"
-          
-          # Return to main directory for cleanup
-          cd "$MAIN_DIR"
-
+      # This deliberately runs last: a GitHub Release means the package
+      # payload passed every gate and its Universe submission was accepted.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: v${{ steps.version.outputs.version }}
-          generate_release_notes: true
-          token: ${{ secrets.PAT_TOKEN }}
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-
-      - name: Upload package as artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: brilliant-cv-${{ steps.version.outputs.version }}
-          path: packages/preview/brilliant-cv/${{ steps.version.outputs.version }}/
-          retention-days: 7
-
-      - name: Workflow Summary
-        run: |
-          echo "=== RELEASE AND PUBLISH COMPLETED ==="
-          echo "✅ Version: ${{ steps.version.outputs.version }}"
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "✅ GitHub release created: v${{ steps.version.outputs.version }}"
-          fi
-          echo "✅ PR created in: typst/packages"
-          echo "✅ Package uploaded as workflow artifact"
-          echo ""
-          echo "🔗 **Next Steps:**"
-          echo "1. Visit https://github.com/typst/packages to review the PR"
-          echo "2. Monitor the PR for any feedback from maintainers"
-          echo "3. Once merged, the package will be available via @preview/brilliant-cv:${{ steps.version.outputs.version }}"
-          echo "4. Update your documentation with the new import statement"
-
-      - name: Restore typst.toml
-        if: always()
-        run: |
-          # Restore original typst.toml regardless of job outcome, so a
-          # failed run never leaves the repo checkout with a bumped
-          # version committed to the working tree.
-          if [ -f "typst.toml.backup" ]; then
-            mv typst.toml.backup typst.toml
-            echo "✅ Original typst.toml restored"
-          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ github.ref_name }}" --generate-notes --verify-tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,38 @@ After CI passes, a maintainer will review. Be ready to:
 - Rebase / squash based on review requests.
 - Provide snippets of rendered output if the diff touches styles or layouts.
 
+## 6. Release workflow
+
+Releases are reviewable changes, not a local one-shot command. From a fully
+clean checkout of the latest `origin/main`, prepare a normal PR with:
+
+```bash
+just prepare-release 4.1.0
+just verify-release
+```
+
+`prepare-release` updates only the manifest and current-version examples.
+Historical imports in the migration guide stay historical. It never commits,
+tags, or pushes on your behalf. Review and merge the version-bump PR normally,
+then create `v4.1.0` on that exact `main` commit.
+
+The tag workflow fails closed unless all of these agree:
+
+- tag, manifest version, starter imports, and current documentation;
+- the tag commit and an immutable commit already present on `origin/main`;
+- the exact `typst.toml` package payload and its `exclude` contract;
+- fresh `typst init` builds of both CV and letter, for all five profiles, on
+  Typst 0.14.0 and 0.15.1;
+- schema, generated docs, public snippets, visual tests, panic tests, and
+  formatting.
+
+Only that verified payload is uploaded and copied into the Typst Universe
+submission. The GitHub Release is created last. Configure the `release`
+environment with required reviewer protection and a fine-grained
+`TYPST_PACKAGES_TOKEN` that can update the maintainer fork and open its upstream
+PR. `PAT_TOKEN` remains only as a temporary compatibility fallback; the normal
+repository `GITHUB_TOKEN` creates the GitHub Release.
+
 ---
 
 Thanks again for contributing! If you hit any setup hurdles, start a discussion or issue before opening a PR so we can keep these docs accurate.

--- a/docs/web/docs/migration.md
+++ b/docs/web/docs/migration.md
@@ -30,7 +30,7 @@ You also need to flatten the v3 `[lang.<code>]` structure to top-level fields. v
 
 ```typ
 // Before (v3)
-#import "@preview/brilliant-cv:4.0.1": cv
+#import "@preview/brilliant-cv:3.3.0": cv
 #let metadata = toml("./metadata.toml")
 #let cv-language = sys.inputs.at("language", default: none)
 #let metadata = if cv-language != none {
@@ -45,6 +45,7 @@ You also need to flatten the v3 `[lang.<code>]` structure to top-level fields. v
 }
 
 // After (v4) — profile-based, no merge
+// release-current-version
 #import "@preview/brilliant-cv:4.0.1": cv
 #let profile = sys.inputs.at("profile", default: "en")
 #let metadata = toml("profile_" + profile + "/metadata.toml")
@@ -179,7 +180,7 @@ The package entry point is unchanged, but you should update any version-pinned i
 #import "@preview/brilliant-cv:2.3.0": *
 
 // After (v3)
-#import "@preview/brilliant-cv:4.0.1": *
+#import "@preview/brilliant-cv:3.3.0": *
 ```
 
 ### 2. Parameter Renaming (now panics)

--- a/justfile
+++ b/justfile
@@ -75,126 +75,31 @@ reset: unlink clean
     @echo "🔄 Development environment reset"
     @echo "💡 Run 'just dev' to start development again"
 
-# Release a new version (bump, build, test, commit, tag, push)
-# Usage: just release 3.2.0
-release version:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    VERSION="{{version}}"
+# Prepare a version-bump PR. This never commits, tags, or pushes.
+# Usage: just prepare-release 4.1.0
+prepare-release version:
+    @python3 scripts/release_contract.py bump "{{version}}"
+    @just docs-generate
+    @just check-version
 
-    # Validate version format
-    if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        echo "❌ Invalid version format: $VERSION"
-        echo "   Expected format: X.Y.Z (e.g., 3.2.0)"
-        exit 1
-    fi
-
-    # Check if tag already exists
-    if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
-        echo "❌ Tag v$VERSION already exists!"
-        echo "   Use a different version number."
-        exit 1
-    fi
-
-    # Check for uncommitted changes
-    if ! git diff --quiet || ! git diff --cached --quiet; then
-        echo "⚠️  You have uncommitted changes:"
-        git status --short
-        echo ""
-        read -p "Continue anyway? [y/N] " -n 1 -r
-        echo
-        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-            echo "Aborted."
-            exit 1
-        fi
-    fi
-
-    # Show what will happen
-    CURRENT=$(grep '^version = ' typst.toml | sed 's/version = "\(.*\)"/\1/')
-    echo "🚀 Release Summary:"
-    echo "   Current version: $CURRENT"
-    echo "   New version:     $VERSION"
-    echo "   Branch:          $(git branch --show-current)"
-    echo ""
-    read -p "Proceed with release? [y/N] " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        echo "Aborted."
-        exit 1
-    fi
-
-    # Do the release
-    echo ""
-    just bump "$VERSION"
-    # Re-link the local package so `@preview/brilliant-cv:$VERSION` imports
-    # in template/ resolve to the local source. Without
-    # this, `just build` fails because the new version isn't yet on Universe
-    # and the local link still points at the old version.
-    just link
-    just build
-    just test
-    git add -A
-    git commit -m "build: bump version to $VERSION"
-    git tag "v$VERSION"
-    git push origin main "v$VERSION"
-    echo ""
-    echo "🎉 Version $VERSION built, tested, committed, tagged, and pushed!"
-
-# Bump version in all files
-# Usage: just bump 3.2.0
-bump version:
-    @echo "📦 Bumping version to {{version}}..."
-    @# Update typst.toml
-    @sed -i.bak 's/^version = ".*"/version = "{{version}}"/' typst.toml && rm -f typst.toml.bak
-    @echo "  ✓ typst.toml"
-    @# Update all template imports in .typ files
-    @find template docs -name "*.typ" -exec sed -i.bak 's/@preview\/brilliant-cv:[0-9]*\.[0-9]*\.[0-9]*/@preview\/brilliant-cv:{{version}}/g' {} \;
-    @find template docs -name "*.bak" -delete
-    @echo "  ✓ template/*.typ and docs/*.typ files"
-    @# Update version strings in documentation markdown files
-    @find docs/web/docs -name "*.md" -exec sed -i.bak 's/brilliant-cv:[0-9]*\.[0-9]*\.[0-9]*/brilliant-cv:{{version}}/g' {} \;
-    @find docs/web/docs -name "*.bak" -delete
-    @echo "  ✓ docs/web/docs/*.md files"
-    @# Update version in API reference generator script
-    @sed -i.bak 's/brilliant-cv:[0-9]*\.[0-9]*\.[0-9]*/brilliant-cv:{{version}}/g' docs/web/generate-api-reference.py && rm -f docs/web/generate-api-reference.py.bak
-    @echo "  ✓ generate-api-reference.py"
-    @echo "✅ Version bumped to {{version}}"
-    @echo ""
-    @echo "📋 Next steps:"
-    @echo "   1. git add -A && git commit -m 'build: bump version to {{version}}'"
-    @echo "   2. git tag v{{version}}"
-    @echo "   3. git push origin main --tags"
-
-# Check that all version references are consistent
+# Check that the manifest, starter, and current documentation agree.
 check-version:
+    @python3 scripts/release_contract.py check-version
+
+# Exercise the release guard itself against an isolated Git fixture.
+release-contract-self-test:
+    @python3 scripts/test_release_contract.py
+
+# Assemble exactly what Typst Universe receives, then compile every starter.
+package-check:
     #!/usr/bin/env bash
     set -euo pipefail
-    TOML_VERSION=$(grep '^version = ' typst.toml | sed 's/version = "\(.*\)"/\1/')
-    echo "📦 Version in typst.toml: $TOML_VERSION"
-    echo ""
-    MISMATCHED=()
-    # Find files with actual version numbers (not <version> placeholders)
-    while IFS= read -r file; do
-        # Skip files that only have placeholder versions like <version>
-        if grep -q "@preview/brilliant-cv:[0-9]" "$file" 2>/dev/null; then
-            if ! grep -q "@preview/brilliant-cv:$TOML_VERSION" "$file" 2>/dev/null; then
-                MISMATCHED+=("$file")
-            fi
-        fi
-    done < <(find template docs -name "*.typ" -exec grep -l "@preview/brilliant-cv:" {} \;)
-    if [ ${#MISMATCHED[@]} -eq 0 ]; then
-        echo "✅ All version references are consistent!"
-        exit 0
-    else
-        echo "❌ Version mismatch in ${#MISMATCHED[@]} files:"
-        for file in "${MISMATCHED[@]}"; do
-            FOUND=$(grep -o "@preview/brilliant-cv:[0-9]*\.[0-9]*\.[0-9]*" "$file" | head -1)
-            echo "   $file → $FOUND"
-        done
-        echo ""
-        echo "💡 Run: just bump $TOML_VERSION"
-        exit 1
-    fi
+    PACKAGE_DIR=$(mktemp -d)/package
+    python3 scripts/release_contract.py assemble "$PACKAGE_DIR"
+    python3 scripts/release_contract.py smoke "$PACKAGE_DIR"
+
+# Full pre-release contract. Tag only after this passes on the version-bump PR.
+verify-release: check-version release-contract-self-test schema-check docs-check test fmt-check package-check
 
 # Validate the editor-facing schema shipped with every initialized starter.
 schema-check:

--- a/scripts/release_contract.py
+++ b/scripts/release_contract.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Fail-closed package and release checks shared by local work and CI."""
+
+from __future__ import annotations
+
+import argparse
+import filecmp
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path, PurePosixPath
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "typst.toml"
+SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+IMPORT = re.compile(r"@preview/brilliant-cv:([0-9]+\.[0-9]+\.[0-9]+)")
+CURRENT_DOC_SOURCES = (
+    ROOT / "docs/web/generate-api-reference.py",
+    ROOT / "docs/web/docs/getting-started.md",
+    ROOT / "docs/web/docs/components.md",
+    ROOT / "docs/web/docs/recipes.md",
+    ROOT / "docs/web/docs/troubleshooting.md",
+)
+MIGRATION_GUIDE = ROOT / "docs/web/docs/migration.md"
+MIGRATION_CURRENT_MARKER = "// release-current-version"
+
+
+class ContractError(RuntimeError):
+    """A release invariant was not satisfied."""
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path = ROOT,
+    capture: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    print("+ " + " ".join(command), flush=True)
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=capture,
+    )
+
+
+def manifest() -> dict[str, object]:
+    with MANIFEST.open("rb") as stream:
+        return tomllib.load(stream)
+
+
+def package_config() -> dict[str, object]:
+    value = manifest().get("package")
+    if not isinstance(value, dict):
+        raise ContractError("typst.toml is missing [package]")
+    return value
+
+
+def payload_package_config(package_dir: Path) -> dict[str, object]:
+    payload_manifest = package_dir / "typst.toml"
+    if not payload_manifest.is_file():
+        raise ContractError(f"not a package payload: {package_dir}")
+    with payload_manifest.open("rb") as stream:
+        value = tomllib.load(stream).get("package")
+    if not isinstance(value, dict):
+        raise ContractError(f"{payload_manifest} is missing [package]")
+    return value
+
+
+def package_version() -> str:
+    value = package_config().get("version")
+    if not isinstance(value, str) or not SEMVER.fullmatch(value):
+        raise ContractError(f"invalid [package].version: {value!r}")
+    return value
+
+
+def current_reference_files() -> list[Path]:
+    files = sorted((ROOT / "template").glob("**/*.typ"))
+    files.extend(path for path in CURRENT_DOC_SOURCES if path.exists())
+    return files
+
+
+def referenced_versions(path: Path) -> set[str]:
+    return set(IMPORT.findall(path.read_text(encoding="utf-8")))
+
+
+def migration_current_version() -> str:
+    text = MIGRATION_GUIDE.read_text(encoding="utf-8")
+    if text.count(MIGRATION_CURRENT_MARKER) != 1:
+        raise ContractError(
+            f"{MIGRATION_GUIDE.relative_to(ROOT)} must contain exactly one "
+            f"{MIGRATION_CURRENT_MARKER!r} marker"
+        )
+    after_marker = text.split(MIGRATION_CURRENT_MARKER, 1)[1]
+    match = IMPORT.search(after_marker)
+    if match is None:
+        raise ContractError("release-current-version marker is not followed by an import")
+    return match.group(1)
+
+
+def check_version() -> None:
+    expected = package_version()
+    errors: list[str] = []
+    references = 0
+    for path in current_reference_files():
+        text = path.read_text(encoding="utf-8")
+        versions = set(IMPORT.findall(text))
+        references += len(IMPORT.findall(text))
+        unexpected = sorted(versions - {expected})
+        if unexpected:
+            errors.append(
+                f"{path.relative_to(ROOT)} uses {', '.join(unexpected)}; "
+                f"expected {expected}"
+            )
+
+    try:
+        migration_version = migration_current_version()
+        references += 1
+        if migration_version != expected:
+            errors.append(
+                f"{MIGRATION_GUIDE.relative_to(ROOT)} current v4 example uses "
+                f"{migration_version}; expected {expected}"
+            )
+    except ContractError as error:
+        errors.append(str(error))
+
+    if references == 0:
+        errors.append("no current-version package imports were found")
+    if errors:
+        raise ContractError("version contract failed:\n  " + "\n  ".join(errors))
+    print(f"Version contract passed: {expected} ({references} current references)")
+
+
+def replace_exact(path: Path, old: str, new: str) -> int:
+    text = path.read_text(encoding="utf-8")
+    before = len(re.findall(rf"@preview/brilliant-cv:{re.escape(old)}\b", text))
+    updated = re.sub(
+        rf"@preview/brilliant-cv:{re.escape(old)}\b",
+        f"@preview/brilliant-cv:{new}",
+        text,
+    )
+    if updated != text:
+        path.write_text(updated, encoding="utf-8")
+    return before
+
+
+def replace_migration_current(old: str, new: str) -> int:
+    text = MIGRATION_GUIDE.read_text(encoding="utf-8")
+    if migration_current_version() != old:
+        raise ContractError("migration guide current-version example is inconsistent")
+    prefix, suffix = text.split(MIGRATION_CURRENT_MARKER, 1)
+    match = IMPORT.search(suffix)
+    assert match is not None
+    suffix = suffix[: match.start(1)] + new + suffix[match.end(1) :]
+    MIGRATION_GUIDE.write_text(prefix + MIGRATION_CURRENT_MARKER + suffix)
+    return 1
+
+
+def check_prepare_state(new: str) -> None:
+    status = run(
+        ["git", "status", "--porcelain", "--untracked-files=all"], capture=True
+    ).stdout
+    if status:
+        raise ContractError(
+            "release preparation requires a fully clean working tree, "
+            "including untracked files"
+        )
+
+    head = run(["git", "rev-parse", "HEAD"], capture=True).stdout.strip()
+    try:
+        main = run(["git", "rev-parse", "origin/main"], capture=True).stdout.strip()
+    except subprocess.CalledProcessError as error:
+        raise ContractError("origin/main is unavailable; fetch it first") from error
+    if head != main:
+        raise ContractError(
+            f"HEAD {head} does not equal local origin/main {main}; synchronize first"
+        )
+    if run(["git", "tag", "--list", f"v{new}"], capture=True).stdout.strip():
+        raise ContractError(f"tag v{new} already exists locally")
+
+
+def bump_version(new: str) -> None:
+    if not SEMVER.fullmatch(new):
+        raise ContractError(f"invalid version {new!r}; expected X.Y.Z")
+    old = package_version()
+    if old == new:
+        raise ContractError(f"typst.toml already declares {new}")
+    check_prepare_state(new)
+    check_version()
+
+    text = MANIFEST.read_text(encoding="utf-8")
+    updated, count = re.subn(
+        rf'(?m)^version = "{re.escape(old)}"$', f'version = "{new}"', text, count=1
+    )
+    if count != 1:
+        raise ContractError("could not update exactly one manifest version")
+    MANIFEST.write_text(updated, encoding="utf-8")
+
+    replacements = sum(
+        replace_exact(path, old, new) for path in current_reference_files()
+    )
+    replacements += replace_migration_current(old, new)
+    if replacements == 0:
+        raise ContractError("no current package imports were updated")
+    check_version()
+    print(
+        f"Prepared version {new}: updated {replacements} current references; "
+        "historical migration imports were preserved."
+    )
+
+
+def git_files() -> list[Path]:
+    # A release payload is a projection of the immutable commit, never of
+    # untracked workstation or runner state.
+    result = run(["git", "ls-files", "--cached", "-z"], capture=True)
+    paths: list[Path] = []
+    for item in result.stdout.split("\0"):
+        if item:
+            path = ROOT / item
+            if path.is_file() or path.is_symlink():
+                paths.append(path)
+    return paths
+
+
+def normalized_excludes() -> tuple[PurePosixPath, ...]:
+    raw = package_config().get("exclude", [])
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise ContractError("[package].exclude must be an array of paths")
+    result: list[PurePosixPath] = []
+    for item in raw:
+        path = PurePosixPath(item)
+        if path.is_absolute() or ".." in path.parts or str(path) in {"", "."}:
+            raise ContractError(f"unsafe package exclude path: {item!r}")
+        result.append(path)
+    return tuple(result)
+
+
+def is_excluded(relative: PurePosixPath, excludes: tuple[PurePosixPath, ...]) -> bool:
+    return any(relative == item or item in relative.parents for item in excludes)
+
+
+def required_payload_paths() -> tuple[PurePosixPath, ...]:
+    return tuple(
+        PurePosixPath(path)
+        for path in (
+            "typst.toml",
+            "src/lib.typ",
+            "template/cv.typ",
+            "template/letter.typ",
+            "template/metadata.toml.schema.json",
+            "thumbnail.png",
+            "README.md",
+            "LICENSE",
+        )
+    )
+
+
+def assemble(output: Path) -> None:
+    output = output.resolve()
+    if output.exists():
+        raise ContractError(f"package output already exists: {output}")
+    if output == ROOT or ROOT in output.parents:
+        raise ContractError("package output must be outside the repository")
+
+    check_version()
+    excludes = normalized_excludes()
+    output.mkdir(parents=True)
+    copied: list[PurePosixPath] = []
+    for source in git_files():
+        relative = PurePosixPath(source.relative_to(ROOT).as_posix())
+        if is_excluded(relative, excludes):
+            continue
+        destination = output / Path(relative)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_symlink():
+            destination.symlink_to(os.readlink(source))
+        else:
+            shutil.copy2(source, destination)
+        copied.append(relative)
+
+    missing = [
+        str(path) for path in required_payload_paths() if not (output / Path(path)).is_file()
+    ]
+    if missing:
+        raise ContractError("package payload is missing: " + ", ".join(missing))
+    print(f"Assembled {len(copied)} files at {output}")
+
+
+def check_payload(package_dir: Path) -> None:
+    package_dir = package_dir.resolve()
+    config = payload_package_config(package_dir)
+    name = config.get("name")
+    version = config.get("version")
+    if name != package_config().get("name") or version != package_version():
+        raise ContractError(
+            f"payload declares {name}:{version}; repository declares "
+            f"{package_config().get('name')}:{package_version()}"
+        )
+
+    missing = [
+        str(path)
+        for path in required_payload_paths()
+        if not (package_dir / Path(path)).is_file()
+    ]
+    if missing:
+        raise ContractError("payload is missing: " + ", ".join(missing))
+    leaked = [
+        str(item)
+        for item in normalized_excludes()
+        if (package_dir / Path(item)).exists()
+    ]
+    if leaked:
+        raise ContractError("payload contains excluded paths: " + ", ".join(leaked))
+    print(f"Package payload contract passed: {name}:{version}")
+
+
+def typst_version() -> str:
+    return run(["typst", "--version"], capture=True).stdout.strip()
+
+
+def smoke(package_dir: Path) -> None:
+    package_dir = package_dir.resolve()
+    check_payload(package_dir)
+    config = payload_package_config(package_dir)
+    name = config["name"]
+    version = config["version"]
+
+    with tempfile.TemporaryDirectory(prefix="brilliant-cv-smoke-") as directory:
+        temporary = Path(directory)
+        package_root = temporary / "packages"
+        local_package = package_root / "preview" / str(name) / str(version)
+        shutil.copytree(package_dir, local_package, symlinks=True)
+        project = temporary / "initialized-project"
+        run(
+            [
+                "typst",
+                "init",
+                "--package-path",
+                str(package_root),
+                f"@preview/{name}:{version}",
+                str(project),
+            ]
+        )
+
+        for entrypoint in ("cv.typ", "letter.typ"):
+            if not (project / entrypoint).is_file():
+                raise ContractError(f"fresh init did not create {entrypoint}")
+            for profile in ("en", "de", "fr", "it", "zh"):
+                output = temporary / f"{entrypoint.removesuffix('.typ')}-{profile}.pdf"
+                run(
+                    [
+                        "typst",
+                        "compile",
+                        "--package-path",
+                        str(package_root),
+                        "--root",
+                        str(project),
+                        "--input",
+                        f"profile={profile}",
+                        str(project / entrypoint),
+                        str(output),
+                    ]
+                )
+    print(f"Fresh-init smoke passed: CV + letter, 5 profiles, {typst_version()}")
+
+
+def check_release_ref(tag: str) -> None:
+    expected_tag = f"v{package_version()}"
+    if tag != expected_tag:
+        raise ContractError(f"tag {tag!r} does not match manifest {expected_tag!r}")
+    check_version()
+    if run(["git", "status", "--porcelain"], capture=True).stdout:
+        raise ContractError("release checkout is not clean")
+
+    head = run(["git", "rev-parse", "HEAD"], capture=True).stdout.strip()
+    tag_commit = run(
+        ["git", "rev-parse", f"refs/tags/{tag}^{{commit}}"], capture=True
+    ).stdout.strip()
+    if head != tag_commit:
+        raise ContractError(f"checkout {head} is not tag commit {tag_commit}")
+    try:
+        run(["git", "merge-base", "--is-ancestor", head, "origin/main"])
+    except subprocess.CalledProcessError as error:
+        raise ContractError(f"tag commit {head} is not on origin/main") from error
+    print(f"Release ref contract passed: {tag} -> {head}")
+
+
+def compare_generated_docs() -> None:
+    target = ROOT / "docs/web/docs/api-reference.md"
+    with tempfile.TemporaryDirectory(prefix="brilliant-cv-docs-") as directory:
+        copy = Path(directory) / "repo"
+        shutil.copytree(
+            ROOT,
+            copy,
+            symlinks=True,
+            ignore=shutil.ignore_patterns(".git", "site", "temp", "__pycache__"),
+        )
+        run([sys.executable, "docs/web/generate-api-reference.py"], cwd=copy)
+        generated = copy / "docs/web/docs/api-reference.md"
+        if not filecmp.cmp(target, generated, shallow=False):
+            raise ContractError(
+                "docs/web/docs/api-reference.md is stale; run `just docs-generate`"
+            )
+    print("Generated API reference is current")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("check-version")
+    bump = commands.add_parser("bump")
+    bump.add_argument("version")
+    assemble_parser = commands.add_parser("assemble")
+    assemble_parser.add_argument("output", type=Path)
+    smoke_parser = commands.add_parser("smoke")
+    smoke_parser.add_argument("package_dir", type=Path)
+    payload = commands.add_parser("check-payload")
+    payload.add_argument("package_dir", type=Path)
+    release_ref = commands.add_parser("check-release-ref")
+    release_ref.add_argument("tag")
+    commands.add_parser("check-generated-docs")
+    args = parser.parse_args()
+
+    try:
+        if args.command == "check-version":
+            check_version()
+        elif args.command == "bump":
+            bump_version(args.version)
+        elif args.command == "assemble":
+            assemble(args.output)
+        elif args.command == "smoke":
+            smoke(args.package_dir)
+        elif args.command == "check-payload":
+            check_payload(args.package_dir)
+        elif args.command == "check-release-ref":
+            check_release_ref(args.tag)
+        elif args.command == "check-generated-docs":
+            compare_generated_docs()
+    except (ContractError, OSError, subprocess.CalledProcessError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_release_contract.py
+++ b/scripts/test_release_contract.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Regression test for safe, targeted release version bumps."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd, check=True, text=True, capture_output=True)
+
+
+def write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="release-contract-test-") as directory:
+        fixture = Path(directory) / "repo"
+        fixture.mkdir()
+        write(
+            fixture / "typst.toml",
+            '[package]\nname = "brilliant-cv"\nversion = "4.0.1"\nexclude = []\n',
+        )
+        write(
+            fixture / "template/cv.typ",
+            '#import "@preview/brilliant-cv:4.0.1": cv\n',
+        )
+        for relative in (
+            "docs/web/generate-api-reference.py",
+            "docs/web/docs/getting-started.md",
+            "docs/web/docs/components.md",
+            "docs/web/docs/recipes.md",
+            "docs/web/docs/troubleshooting.md",
+        ):
+            write(fixture / relative, '#import "@preview/brilliant-cv:4.0.1": cv\n')
+        write(
+            fixture / "docs/web/docs/migration.md",
+            """\
+```typ
+#import "@preview/brilliant-cv:3.3.0": cv
+```
+
+// release-current-version
+
+```typ
+#import "@preview/brilliant-cv:4.0.1": cv
+```
+
+```typ
+#import "@preview/brilliant-cv:2.0.8": *
+```
+""",
+        )
+        (fixture / "scripts").mkdir()
+        shutil.copy2(ROOT / "scripts/release_contract.py", fixture / "scripts")
+
+        run(["git", "init", "--quiet"], fixture)
+        run(["git", "config", "user.name", "release-contract-test"], fixture)
+        run(["git", "config", "user.email", "test@example.invalid"], fixture)
+        run(["git", "config", "commit.gpgsign", "false"], fixture)
+        run(["git", "add", "."], fixture)
+        run(["git", "commit", "--quiet", "-m", "fixture"], fixture)
+        run(["git", "update-ref", "refs/remotes/origin/main", "HEAD"], fixture)
+
+        dirty_file = fixture / "untracked-work.txt"
+        write(dirty_file, "do not overwrite contributor work\n")
+        dirty_result = subprocess.run(
+            [sys.executable, "scripts/release_contract.py", "bump", "4.0.2"],
+            cwd=fixture,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert dirty_result.returncode != 0
+        assert "fully clean working tree" in dirty_result.stderr
+        assert 'version = "4.0.1"' in (fixture / "typst.toml").read_text()
+        dirty_file.unlink()
+
+        result = run(
+            [sys.executable, "scripts/release_contract.py", "bump", "4.0.2"], fixture
+        )
+        assert "Version contract passed: 4.0.2" in result.stdout
+        assert 'version = "4.0.2"' in (fixture / "typst.toml").read_text()
+        assert "brilliant-cv:4.0.2" in (fixture / "template/cv.typ").read_text()
+
+        migration = (fixture / "docs/web/docs/migration.md").read_text()
+        assert migration.count("brilliant-cv:4.0.2") == 1
+        assert migration.count("brilliant-cv:4.0.1") == 0
+        assert migration.count("brilliant-cv:3.3.0") == 1
+        assert migration.count("brilliant-cv:2.0.8") == 1
+
+        run(["git", "add", "."], fixture)
+        run(["git", "commit", "--quiet", "-m", "prepare 4.0.2"], fixture)
+        run(["git", "update-ref", "refs/remotes/origin/main", "HEAD"], fixture)
+        run(["git", "tag", "v4.0.2"], fixture)
+        release_ref = run(
+            [
+                sys.executable,
+                "scripts/release_contract.py",
+                "check-release-ref",
+                "v4.0.2",
+            ],
+            fixture,
+        )
+        assert "Release ref contract passed" in release_ref.stdout
+
+    print("release-contract bump regression passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/typst.toml
+++ b/typst.toml
@@ -20,6 +20,7 @@ compiler = "0.14.0"
 exclude = [
     "docs",
     "tests",
+    "scripts",
     "justfile",
     ".github",
     ".pre-commit-config.yaml",


### PR DESCRIPTION
## Summary

- replace the mutable release job with a tag-only, fail-closed pipeline
- require tag, manifest, current docs, exact payload, and origin/main ancestry to agree
- fresh-init and compile CV and letter for all five profiles on Typst 0.14.0 and 0.15.1
- upload once and submit that exact verified payload to Typst Universe
- replace the local auto-commit/tag/push command with a reviewable version-bump PR flow

## Safety boundaries

- no workflow_dispatch release path and no version mutation in CI
- no force-reset or deletion of the fork main branch
- automation branches use force-with-lease only on an exact observed SHA
- the GitHub Release is created last, after verification and Universe submission
- publishing is gated by the protected release environment

## Validation

- release-contract regression test
- actionlint 1.7.7 with verified official checksum
- fresh-init CV and letter, five profiles, Typst 0.14.0 and 0.15.1
- schema validation and 9 generated API snippet compiles
- 49/49 tytanic tests and 14/14 panic tests
- Docker typstyle check