### PR TITLE
chore: prepare 4.1.0 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,9 +15,9 @@ body:
     attributes:
       label: brilliant-cv version
       description: >
-        The version you imported, e.g. from `#import "@preview/brilliant-cv:4.0.1"` in your
+        The version you imported, e.g. from `#import "@preview/brilliant-cv:4.1.0"` in your
         `cv.typ`/`letter.typ`, or from `typst.toml` if you develop against a local checkout.
-      placeholder: "4.0.1"
+      placeholder: "4.1.0"
     validations:
       required: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,10 +161,11 @@ The tag workflow fails closed unless all of these agree:
 
 Only that verified payload is uploaded and copied into the Typst Universe
 submission. The GitHub Release is created last. Configure the `release`
-environment with required reviewer protection and a fine-grained
-`TYPST_PACKAGES_TOKEN` that can update the maintainer fork and open its upstream
-PR. `PAT_TOKEN` remains only as a temporary compatibility fallback; the normal
-repository `GITHUB_TOKEN` creates the GitHub Release.
+environment with required reviewer protection and a dedicated classic
+`TYPST_PACKAGES_TOKEN` limited to the `public_repo` scope. The workflow needs
+that cross-repository scope both to update the maintainer fork and to open the
+upstream PR. `PAT_TOKEN` remains only as a temporary compatibility fallback;
+the normal repository `GITHUB_TOKEN` creates the GitHub Release.
 
 ### Reproducible automation
 

--- a/docs/web/docs/components.md
+++ b/docs/web/docs/components.md
@@ -26,7 +26,7 @@ The `cv()` function is the main entry point. It runs schema-migration guards (pa
 By default, `header-info: auto` renders the entries from `metadata.personal.info`. Pass content to replace that row without reimplementing the name, photo, or header layout:
 
 ```typ
-#import "@preview/brilliant-cv:4.0.1": cv, h-bar
+#import "@preview/brilliant-cv:4.1.0": cv, h-bar
 
 #let info = metadata.personal.info
 

--- a/docs/web/docs/getting-started.md
+++ b/docs/web/docs/getting-started.md
@@ -11,7 +11,7 @@ typst init @preview/brilliant-cv
 Replace the version with the latest or any release (after 2.0.0) if needed:
 
 ```bash
-typst init @preview/brilliant-cv:4.0.1
+typst init @preview/brilliant-cv:4.1.0
 ```
 
 ## Step 2: Install Fonts
@@ -66,7 +66,7 @@ The most important keys to set first:
 Open `profile_en/education.typ` and replace its contents with:
 
 ```typ
-#import "@preview/brilliant-cv:4.0.1": cv-section, cv-entry
+#import "@preview/brilliant-cv:4.1.0": cv-section, cv-entry
 
 #cv-section("Education")
 

--- a/docs/web/docs/migration.md
+++ b/docs/web/docs/migration.md
@@ -46,7 +46,7 @@ You also need to flatten the v3 `[lang.<code>]` structure to top-level fields. v
 
 // After (v4) — profile-based, no merge
 // release-current-version
-#import "@preview/brilliant-cv:4.0.1": cv
+#import "@preview/brilliant-cv:4.1.0": cv
 #let profile = sys.inputs.at("profile", default: "en")
 #let metadata = toml("profile_" + profile + "/metadata.toml")
 #let import-modules(modules) = {

--- a/docs/web/docs/recipes.md
+++ b/docs/web/docs/recipes.md
@@ -137,7 +137,7 @@ When a `custom-icons` entry is provided, it takes priority over the `awesomeIcon
 The default header turns `[personal.info]` entries into linked contact items, inserts icons, and places `h-bar()` between them automatically. When you need precise control over separators, line breaks, or which spans use the accent color, pass custom content through `header-info`:
 
 ```typ
-#import "@preview/brilliant-cv:4.0.1": cv, h-bar
+#import "@preview/brilliant-cv:4.1.0": cv, h-bar
 
 #let info = metadata.personal.info
 
@@ -202,7 +202,7 @@ awesome_color = "#1E90FF"
 Create a cover letter with a signature image at the bottom:
 
 ```typ
-#import "@preview/brilliant-cv:4.0.1": letter
+#import "@preview/brilliant-cv:4.1.0": letter
 
 #let metadata = toml("metadata.toml")
 

--- a/docs/web/docs/troubleshooting.md
+++ b/docs/web/docs/troubleshooting.md
@@ -24,7 +24,7 @@ does not bundle the font files themselves.
 Make sure you import `h-bar` from the package:
 
 ```typ
-#import "@preview/brilliant-cv:4.0.1": h-bar
+#import "@preview/brilliant-cv:4.1.0": h-bar
 ```
 
 The old name `hBar` has been removed in v3. See the [Migration Guide](migration.md) for all renamed functions.

--- a/scripts/release_contract.py
+++ b/scripts/release_contract.py
@@ -19,7 +19,8 @@ ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = ROOT / "typst.toml"
 SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 IMPORT = re.compile(r"@preview/brilliant-cv:([0-9]+\.[0-9]+\.[0-9]+)")
-CURRENT_DOC_SOURCES = (
+CURRENT_VERSION_SOURCES = (
+    ROOT / ".github/ISSUE_TEMPLATE/bug_report.yml",
     ROOT / "docs/web/generate-api-reference.py",
     ROOT / "docs/web/docs/getting-started.md",
     ROOT / "docs/web/docs/components.md",
@@ -82,7 +83,7 @@ def package_version() -> str:
 
 def current_reference_files() -> list[Path]:
     files = sorted((ROOT / "template").glob("**/*.typ"))
-    files.extend(path for path in CURRENT_DOC_SOURCES if path.exists())
+    files.extend(path for path in CURRENT_VERSION_SOURCES if path.exists())
     return files
 
 

--- a/scripts/test_release_contract.py
+++ b/scripts/test_release_contract.py
@@ -35,6 +35,7 @@ def main() -> int:
             '#import "@preview/brilliant-cv:4.0.1": cv\n',
         )
         for relative in (
+            ".github/ISSUE_TEMPLATE/bug_report.yml",
             "docs/web/generate-api-reference.py",
             "docs/web/docs/getting-started.md",
             "docs/web/docs/components.md",
@@ -91,6 +92,9 @@ def main() -> int:
         assert "Version contract passed: 4.0.2" in result.stdout
         assert 'version = "4.0.2"' in (fixture / "typst.toml").read_text()
         assert "brilliant-cv:4.0.2" in (fixture / "template/cv.typ").read_text()
+        assert "brilliant-cv:4.0.2" in (
+            fixture / ".github/ISSUE_TEMPLATE/bug_report.yml"
+        ).read_text()
 
         migration = (fixture / "docs/web/docs/migration.md").read_text()
         assert migration.count("brilliant-cv:4.0.2") == 1

--- a/template/cv.typ
+++ b/template/cv.typ
@@ -8,7 +8,7 @@
 // See https://yunanwg.github.io/brilliant-CV/ (Troubleshooting) for details.
 
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv, h-bar
+#import "@preview/brilliant-cv:4.1.0": cv, h-bar
 
 // Each profile lives in its own folder with a self-contained metadata.toml.
 // Switch profile at compile time:

--- a/template/letter.typ
+++ b/template/letter.typ
@@ -8,7 +8,7 @@
 // See https://yunanwg.github.io/brilliant-CV/ (Troubleshooting) for details.
 
 // Imports
-#import "@preview/brilliant-cv:4.0.1": letter
+#import "@preview/brilliant-cv:4.1.0": letter
 
 // Each profile lives in its own folder with a self-contained metadata.toml.
 // Switch profile at compile time:

--- a/template/profile_de/certificates.typ
+++ b/template/profile_de/certificates.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-honor, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-honor, cv-section
 
 
 #cv-section("Zertifikate")

--- a/template/profile_de/education.typ
+++ b/template/profile_de/education.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-entry, cv-section, h-bar
+#import "@preview/brilliant-cv:4.1.0": cv-entry, cv-section, h-bar
 
 
 #cv-section("Abschlüsse")

--- a/template/profile_de/professional.typ
+++ b/template/profile_de/professional.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": (
+#import "@preview/brilliant-cv:4.1.0": (
   cv-entry, cv-entry-continued, cv-entry-start, cv-section,
 )
 

--- a/template/profile_de/projects.typ
+++ b/template/profile_de/projects.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-entry, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-entry, cv-section
 
 
 #cv-section("Projekte und Verbände")

--- a/template/profile_de/publications.typ
+++ b/template/profile_de/publications.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-publication, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-publication, cv-section
 
 
 #cv-section("Veröffentlichungen")

--- a/template/profile_de/skills.typ
+++ b/template/profile_de/skills.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": (
+#import "@preview/brilliant-cv:4.1.0": (
   cv-section, cv-skill, cv-skill-tag, cv-skill-with-level, h-bar,
 )
 

--- a/template/profile_en/certificates.typ
+++ b/template/profile_en/certificates.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-honor, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-honor, cv-section
 
 
 #cv-section("Certificates & Awards")

--- a/template/profile_en/education.typ
+++ b/template/profile_en/education.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-entry, cv-section, h-bar
+#import "@preview/brilliant-cv:4.1.0": cv-entry, cv-section, h-bar
 
 
 #cv-section("Education")

--- a/template/profile_en/professional.typ
+++ b/template/profile_en/professional.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": (
+#import "@preview/brilliant-cv:4.1.0": (
   cv-entry, cv-entry-continued, cv-entry-start, cv-section,
 )
 

--- a/template/profile_en/projects.typ
+++ b/template/profile_en/projects.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-entry, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-entry, cv-section
 
 
 #cv-section("Projects & Associations")

--- a/template/profile_en/publications.typ
+++ b/template/profile_en/publications.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-publication, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-publication, cv-section
 
 
 #cv-section("Publications")

--- a/template/profile_en/skills.typ
+++ b/template/profile_en/skills.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": (
+#import "@preview/brilliant-cv:4.1.0": (
   cv-section, cv-skill, cv-skill-tag, cv-skill-with-level, h-bar,
 )
 

--- a/template/profile_fr/certificates.typ
+++ b/template/profile_fr/certificates.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-honor, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-honor, cv-section
 
 
 #cv-section("Certificates")

--- a/template/profile_fr/education.typ
+++ b/template/profile_fr/education.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-entry, cv-section, h-bar
+#import "@preview/brilliant-cv:4.1.0": cv-entry, cv-section, h-bar
 
 
 #cv-section("Formation")

--- a/template/profile_fr/professional.typ
+++ b/template/profile_fr/professional.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": (
+#import "@preview/brilliant-cv:4.1.0": (
   cv-entry, cv-entry-continued, cv-entry-start, cv-section,
 )
 

--- a/template/profile_fr/projects.typ
+++ b/template/profile_fr/projects.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-entry, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-entry, cv-section
 
 
 #cv-section("Projets & Associations")

--- a/template/profile_fr/publications.typ
+++ b/template/profile_fr/publications.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-publication, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-publication, cv-section
 
 
 #cv-section("Publications")

--- a/template/profile_fr/skills.typ
+++ b/template/profile_fr/skills.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-section, cv-skill, h-bar
+#import "@preview/brilliant-cv:4.1.0": cv-section, cv-skill, h-bar
 
 
 #cv-section("Compétences")

--- a/template/profile_it/certificates.typ
+++ b/template/profile_it/certificates.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-honor, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-honor, cv-section
 
 
 #cv-section("Certificazioni")

--- a/template/profile_it/education.typ
+++ b/template/profile_it/education.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-entry, cv-section, h-bar
+#import "@preview/brilliant-cv:4.1.0": cv-entry, cv-section, h-bar
 
 
 #cv-section("Istruzione")

--- a/template/profile_it/professional.typ
+++ b/template/profile_it/professional.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": (
+#import "@preview/brilliant-cv:4.1.0": (
   cv-entry, cv-entry-continued, cv-entry-start, cv-section,
 )
 

--- a/template/profile_it/projects.typ
+++ b/template/profile_it/projects.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-entry, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-entry, cv-section
 
 
 #cv-section("Progetti")

--- a/template/profile_it/publications.typ
+++ b/template/profile_it/publications.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-publication, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-publication, cv-section
 
 
 #cv-section("Pubblicazioni")

--- a/template/profile_it/skills.typ
+++ b/template/profile_it/skills.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-section, cv-skill, h-bar
+#import "@preview/brilliant-cv:4.1.0": cv-section, cv-skill, h-bar
 
 
 #cv-section("Competenze")

--- a/template/profile_zh/certificates.typ
+++ b/template/profile_zh/certificates.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-honor, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-honor, cv-section
 
 
 #cv-section("证书")

--- a/template/profile_zh/education.typ
+++ b/template/profile_zh/education.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-entry, cv-section, h-bar
+#import "@preview/brilliant-cv:4.1.0": cv-entry, cv-section, h-bar
 
 
 #cv-section("教育经历")

--- a/template/profile_zh/professional.typ
+++ b/template/profile_zh/professional.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": (
+#import "@preview/brilliant-cv:4.1.0": (
   cv-entry, cv-entry-continued, cv-entry-start, cv-section,
 )
 

--- a/template/profile_zh/projects.typ
+++ b/template/profile_zh/projects.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-entry, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-entry, cv-section
 
 
 #cv-section("项目与协会")

--- a/template/profile_zh/publications.typ
+++ b/template/profile_zh/publications.typ
@@ -1,5 +1,5 @@
 // Imports
-#import "@preview/brilliant-cv:4.0.1": cv-publication, cv-section
+#import "@preview/brilliant-cv:4.1.0": cv-publication, cv-section
 
 
 #cv-section("学术著作")

--- a/template/profile_zh/skills.typ
+++ b/template/profile_zh/skills.typ
@@ -1,5 +1,5 @@
 // Import
-#import "@preview/brilliant-cv:4.0.1": cv-section, cv-skill, h-bar
+#import "@preview/brilliant-cv:4.1.0": cv-section, cv-skill, h-bar
 
 
 #cv-section("技能与兴趣")

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brilliant-cv"
-version = "4.0.1"
+version = "4.1.0"
 entrypoint = "src/lib.typ"
 authors = ["Yunan Wang <https://github.com/yunanwg>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- bump the package manifest, starter imports, current docs, and bug-report guidance to 4.1.0
- include the bug-report issue form in the automated version contract
- document the cross-repository release credential as a dedicated classic PAT limited to `public_repo`

## Why

This prepares the first release using the new fail-closed release pipeline. Running the release command exposed two preparation gaps: the issue form retained the old version, and a fine-grained token scoped to the maintainer fork cannot also obtain pull-request write permission on the upstream `typst/packages` repository.

## Impact

There is no additional public API change in this PR. Existing projects remain compatible; new projects receive the features and safer defaults already merged since 4.0.1.

## Validation

- `just build`
- `just verify-release`
  - 49/49 visual and unit tests
  - 14/14 panic tests
  - strict schema validation for all five profiles
  - generated docs and nine public snippets
  - formatting and CI contract checks
  - exact package assembly and fresh-init CV + letter smoke tests for all five profiles
