### PR TITLE
ci: make sponsor refresh manual-only

### DIFF
--- a/.github/workflows/sponsors.yaml
+++ b/.github/workflows/sponsors.yaml
@@ -1,8 +1,6 @@
 name: Update Sponsors
 
 on:
-  schedule:
-    - cron: '0 0 * * 0'
   workflow_dispatch:
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,12 +183,12 @@ uv pip compile --universal --generate-hashes scripts/requirements-checks.txt --o
 Commit each input file and its regenerated lockfile together. Dependabot covers
 both Python directories as well as GitHub Actions.
 
-The weekly sponsor refresh uses two separate credentials: a read-only
-`SPONSORS_TOKEN` for the Sponsors API and a repository-scoped
+The manually dispatched sponsor refresh uses two separate credentials: a
+read-only `SPONSORS_TOKEN` for the Sponsors API and a repository-scoped
 `AUTOMATION_PR_TOKEN` that may push only the automation branch and open its PR.
-It never writes directly to `main`. The manual visual-ref workflow likewise
-refuses to run on `main`; dispatch it from the feature branch whose refs you
-intend to review.
+Run it only after both secrets are configured. It never writes directly to
+`main`. The manual visual-ref workflow likewise refuses to run on `main`;
+dispatch it from the feature branch whose refs you intend to review.
 
 ---
 

--- a/scripts/check_ci_contract.py
+++ b/scripts/check_ci_contract.py
@@ -54,6 +54,12 @@ def policy_errors(root: Path) -> list[str]:
         if forbidden in release:
             errors.append(f"release workflow contains forbidden operation: {forbidden}")
 
+    sponsors = (root / ".github/workflows/sponsors.yaml").read_text()
+    if "workflow_dispatch:" not in sponsors:
+        errors.append("sponsor refresh must remain manually dispatchable")
+    if "schedule:" in sponsors:
+        errors.append("sponsor refresh must remain manual-only")
+
     precommit = (root / ".pre-commit-config.yaml").read_text()
     if "delete-all-pdfs" in precommit or 'find . -type f -name "*.pdf" -delete' in precommit:
         errors.append("pre-commit must reject PDFs, not delete workspace files")


### PR DESCRIPTION
## Summary

- remove the weekly Sponsor refresh schedule
- keep the workflow available through `workflow_dispatch`
- document that both Sponsor credentials are needed only when the manual workflow is run
- guard the manual-only policy in the CI contract

## Why

Sponsor changes are infrequent, so a scheduled workflow would either require long-lived credentials or produce recurring failures while those secrets are intentionally absent.

## Validation

- `just ci-contract-check`
- `just build`
- `just test` (49/49 tests and 14/14 panic tests)
