### PR TITLE
fix: make release upstream setup idempotent

### DIFF
--- a/.github/workflows/release-and-publish.yaml
+++ b/.github/workflows/release-and-publish.yaml
@@ -144,7 +144,11 @@ jobs:
           gh auth setup-git
           gh repo clone yunanwg/our-Typst-packages universe
           cd universe
-          git remote add upstream https://github.com/typst/packages.git
+          if git remote get-url upstream >/dev/null 2>&1; then
+            git remote set-url upstream https://github.com/typst/packages.git
+          else
+            git remote add upstream https://github.com/typst/packages.git
+          fi
           git fetch --no-tags upstream main
 
           TARGET="packages/preview/brilliant-cv/$VERSION"

--- a/scripts/check_ci_contract.py
+++ b/scripts/check_ci_contract.py
@@ -42,6 +42,21 @@ def docker_errors(text: str) -> list[str]:
     return errors
 
 
+def release_remote_errors(text: str) -> list[str]:
+    """Reject fork-clone remote setup that is not safe to repeat."""
+    if "gh repo clone" not in text or "git remote add upstream" not in text:
+        return []
+    if (
+        "git remote get-url upstream" in text
+        and "git remote set-url upstream" in text
+    ):
+        return []
+    return [
+        "release workflow must handle the upstream remote that gh repo clone "
+        "may create for forks"
+    ]
+
+
 def policy_errors(root: Path) -> list[str]:
     errors: list[str] = []
     for path in sorted((root / ".github/workflows").glob("*.yaml")):
@@ -50,6 +65,7 @@ def policy_errors(root: Path) -> list[str]:
     errors.extend(docker_errors((root / "tests/Dockerfile").read_text()))
 
     release = (root / ".github/workflows/release-and-publish.yaml").read_text()
+    errors.extend(release_remote_errors(release))
     for forbidden in ("workflow_dispatch", "git reset --hard", "git push origin main --force"):
         if forbidden in release:
             errors.append(f"release workflow contains forbidden operation: {forbidden}")
@@ -83,6 +99,20 @@ def self_test() -> None:
     assert not action_errors(Path("ok.yaml"), "uses: owner/action@" + "a" * 40)
     assert action_errors(Path("bad.yaml"), "uses: owner/action@v7")
     assert docker_errors("FROM ubuntu:24.04\nRUN curl https://github.com/x\n")
+    unsafe_remote = """\
+gh repo clone owner/fork universe
+git remote add upstream https://github.com/upstream/repo.git
+"""
+    safe_remote = """\
+gh repo clone owner/fork universe
+if git remote get-url upstream >/dev/null 2>&1; then
+  git remote set-url upstream https://github.com/upstream/repo.git
+else
+  git remote add upstream https://github.com/upstream/repo.git
+fi
+"""
+    assert release_remote_errors(unsafe_remote)
+    assert not release_remote_errors(safe_remote)
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

- handle the `upstream` remote that `gh repo clone` may already create for forks
- add a CI contract regression guard for unsafe duplicate remote setup

## Root cause

The v4.1.0 publish job cloned the maintainer fork with `gh repo clone`, which automatically configured its parent as `upstream`. The next command attempted to add the same remote again and exited before creating the Typst Universe submission.

## Impact

Future release jobs accept both possible clone states: an existing `upstream` remote is normalized to `typst/packages`, while a missing one is added. This changes only release automation; the package API and payload are unchanged. The existing v4.1.0 tag is not moved or replaced.

## Verification

- `just build`
- `just test` (49/49 visual and unit tests, 14/14 panic tests)
- `just fmt-check`
- `just ci-contract-check`
- `python3 scripts/test_release_contract.py`
- exercised both existing-remote and missing-remote paths in temporary Git repositories
