### PR TITLE
chore(github): tune Claude Code workflows for this repo

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,13 +2,16 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # Review once when a PR opens or leaves draft. `synchronize` is intentionally
+    # omitted so follow-up pushes don't re-run the review on every commit — tag
+    # @claude manually if a later revision needs another pass.
+    types: [opened, ready_for_review]
+    # Only review changes to the published package and the user-facing template.
+    # Docs-only / tests-only / CI-only PRs skip AI review, mirroring the repo
+    # convention that such changes also skip regression tests.
+    paths:
+      - "src/**"
+      - "template/**"
 
 jobs:
   claude-review:
@@ -39,6 +42,6 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          # Pin the model and cap iterations to keep review cost predictable.
+          claude_args: '--model claude-sonnet-5 --max-turns 15'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,21 +30,33 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Give Claude a real Typst toolchain so it can compile-test its own
+      # changes and run the native panic/guard suites before opening a PR.
+      # The tytanic visual-regression suite (Docker + pinned fonts) is left to
+      # test.yaml on the PR Claude opens — reproducing it here is heavy and the
+      # pixel refs are not deterministic outside the test image.
+      - name: Set up Typst
+        uses: typst-community/setup-typst@v4
+      - name: Set up just
+        uses: extractions/setup-just@v2
+      - name: Link local package
+        run: just link
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # Allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+          # Pin the model, cap iterations, and scope tools to this repo's
+          # verification loop: typst compile + native panics + machine guards.
+          # Visual regressions are verified by CI, not here.
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 20
+            --allowedTools "Edit,Read,Write,Bash(just link),Bash(typst compile:*),Bash(bash tests/panics/run.sh),Bash(bash tests/guards.sh)"
 


### PR DESCRIPTION
Customizes the two Claude Code workflows added in #229 for how this repo actually works.

## Interactive `@claude` (`claude.yml`)
- Install Typst + `just` and run `just link` before the action, so Claude can compile-test its own changes and run the native panic/guard suites before opening a PR. The tytanic visual-regression suite stays in `test.yaml` — Docker + pinned fonts, not pixel-deterministic outside the test image.
- Pin model to `claude-sonnet-5`, cap at 20 turns, and scope `allowedTools` to the verification loop (`typst compile`, `tests/panics/run.sh`, `tests/guards.sh`, `just link`).

## Auto review (`claude-code-review.yml`)
- Drop `synchronize`/`reopened` — review on `opened`/`ready_for_review` only. Tag `@claude` manually if a later revision needs another pass.
- Add a `paths` filter (`src/**`, `template/**`) so docs-only / tests-only / CI-only PRs skip AI review, mirroring the convention that such changes also skip regression tests.
- Pin model to `claude-sonnet-5`, cap at 15 turns.

## Fork PRs
Left on `pull_request` (not `pull_request_target`): fork PRs get empty secrets and the action no-ops before spending credits. External-contributor PRs are covered on demand by commenting `@claude` (comment events run in base-repo context with secrets), keeping a human in the loop before AI runs on untrusted code.