### PR TITLE
build(justfile): warn that test-fast skips the visual suite

### DIFF
--- a/justfile
+++ b/justfile
@@ -185,16 +185,21 @@ test: test-image
     @bash tests/guards.sh
     @docker run --rm --platform={{DOCKER_PLATFORM}} -v "$(pwd):/workspace" {{DOCKER_IMAGE}} bash -c "tt run --no-fail-fast && bash tests/panics/run.sh"
 
-# Compile-only tests (panics + units) — runs native, no Docker, sub-second
-#
 # No `link` prerequisite: units/ and panics/ fixtures use root-relative
 # imports (`/src/...`, `/tests/...`), never `@preview/brilliant-cv:...`, so
 # utpm's local package link is not needed here (confirmed via
 # `grep -r '@preview' tests/units tests/panics` — no matches).
+
+# Compile-only tests, native and sub-second. Runs NO visual regression tests.
 test-fast:
     @tt run --no-fail-fast -e 'glob:"units/*"'
     @bash tests/panics/run.sh
     @bash tests/guards.sh
+    @echo
+    @echo "⚠️  Visual regression tests did NOT run. This suite is compile-only:"
+    @echo "   layout, spacing and glyph changes are invisible to it. Verify with"
+    @echo "   'just test' on arm64, or let CI check the refs, before concluding"
+    @echo "   that a change has no visual impact."
 
 # Run only the panic-fixture shell-script smoke tests (native)
 test-panics:


### PR DESCRIPTION
## Problem

`just test-fast` prints only its passing results and says nothing about what it did not run. On x86_64 that output is the *only* local signal a contributor gets: the test image is arm64-only (`justfile` pins `DOCKER_PLATFORM := "linux/arm64"`, see the rationale in `tests/Dockerfile`), so `just test` cannot run for them at all.

A green run therefore reads as "my change is fine" when it carries no information about layout, spacing, or glyphs.

This is not hypothetical. In #236 the contributor ran `just test-fast`, saw 20/20 units + 14/14 panics + 2/2 guards pass, and concluded in the PR description that the change was "not otherwise a visual regression, no ref PNGs affected". It was, and all five `regression/cv-*` refs failed once CI ran. `tests/README.md:89` already tells x86_64 contributors to rely on CI for visuals, but nothing repeats that at the moment the misleading output appears.

## Change

Two lines of defence, both in `justfile`:

- Print an explicit notice after `test-fast` passes, naming what was skipped and how to actually verify it.
- Reword the `just --list` description to `Compile-only tests, native and sub-second. Runs NO visual regression tests.` The previous description was an artefact: `just` takes the last line of the adjacent comment block, which was the tail of a parenthetical about `@preview` imports. Moving the explanatory block above a blank line fixes what `just --list` shows without losing the explanation.

Output on success:

```
Panic tests: 14 passed, 0 failed
Guards: 2 passed, 0 failed

⚠️  Visual regression tests did NOT run. This suite is compile-only:
   layout, spacing and glyph changes are invisible to it. Verify with
   'just test' on arm64, or let CI check the refs, before concluding
   that a change has no visual impact.
```

The notice prints only when the suite passes. A failing run already tells the contributor to look closer, so there is nothing to disambiguate there.

## Testing

- `just test` (Docker, arm64): 50/50 tytanic, 14/14 panics, 2/2 guards
- `just ci-contract-check`: passes
- `just --list` shows the new description
- Warning block rendered and checked verbatim

No behaviour change to any test; this only adds output.