### PR TITLE
docs: rewrite hand-written pages in Simplified Technical English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,35 @@ Brilliant CV deliberately balances simplicity against flexibility. Before adding
 
 See the “Public API design” section in `CONTRIBUTING.md` for the contributor-facing rationale and decision checklist.
 
+## Documentation Style
+
+The hand-written pages under `docs/web/docs/` follow ASD-STE100 Simplified Technical English. Most readers of this project are not native English speakers, and these rules keep the pages short, unambiguous, and easy to translate.
+
+Recommended tool: the `simple-english` skill at <https://github.com/AminBlg/SimpleEnglish>. It carries the 53-rule catalog and a mandatory self-check. Use **pragmatic mode**, which keeps domain vocabulary (Typst, profile, metadata, compile). The skill is not vendored in this repository; install it yourself.
+
+In scope: `index.md`, `getting-started.md`, `troubleshooting.md`, `recipes.md`, `migration.md`, `components.md`.
+
+Out of scope: `api-reference.md` and `configuration.md` are generated. To change their prose, edit the doc-comments in `src/` or the comments in `template/profile_en/metadata.toml`, then run `just docs-generate`.
+
+Never rewrite code blocks, inline code, file paths, commands, config keys, or quoted errors. Reflow the prose around them. `just docs-check` does **not** gate these pages: it compiles the snippets in the generated `api-reference.md` only. Verify by diffing every code block and link target against the previous revision.
+
+### Terminology
+
+One term per concept, across every page. These choices are already applied:
+
+| Concept | Use | Not |
+|---|---|---|
+| Configuration data | `configuration` | `config` |
+| The published library | `package` | `framework` |
+| The starter project a user copies | `template` | — |
+| Filesystem location | `directory` | `folder` |
+| Taking something away | `remove` | `delete` |
+| What Typst puts on the page | `render` | `display` |
+| Making information visible to a reader | `show` | `display` |
+| Confirming a state | `make sure that` | `check`, `verify`, `confirm` |
+
+Write `for example` and `that is` instead of `e.g.` and `i.e.` Name the items instead of writing `etc.`
+
 ## Conventions
 
 - Conventional commits (`feat:`, `fix:`, `docs:`, etc.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,7 @@ If existing composition is clear enough, prefer documenting that approach. If a 
 2. **Document anything user-facing**:
    - Update `README.md` (or `docs/`) for new parameters.
    - Add comments to `metadata.toml` if you introduce new knobs.
+   - The hand-written pages under `docs/web/docs/` follow Simplified Technical English, with a fixed terminology table. Read the “Documentation Style” section in `AGENTS.md` before you write prose there.
 3. **Keep compatibility**:
    - For renamed parameters, follow the aliasing approach already used in `src/lib.typ`.
    - Don’t remove template options without deprecation notes.

--- a/docs/web/docs/components.md
+++ b/docs/web/docs/components.md
@@ -1,14 +1,14 @@
 # Component Gallery
 
-These are the building blocks of your CV. Each example below is followed by the actual rendered output — the PNGs are the same ones the [test suite](https://github.com/yunanwg/brilliant-CV/tree/main/tests/components) uses as visual-regression baselines, so what you see here is exactly what the package produces. For full parameter details, see the [API Reference](api-reference.md).
+These are the building blocks of your CV. Each example has the rendered output after it. The PNGs are the same files that the [test suite](https://github.com/yunanwg/brilliant-CV/tree/main/tests/components) uses as visual-regression baselines, so this page shows exactly what the package produces. For the full parameter details, see the [API Reference](api-reference.md).
 
 ## Component context in v4
 
-CV components normally read layout settings from the metadata context installed by the enclosing `#show: cv.with(metadata, ...)` rule. Typst state is contextual and positional, so keep component calls inside the `cv()` document body, as the starter does. For standalone composition or tests, pass `metadata: metadata` explicitly; this is a supported escape hatch documented in each applicable component signature.
+CV components usually read the layout configuration from the metadata context. The enclosing `#show: cv.with(metadata, ...)` rule installs this context. Typst state is contextual and positional, so the component calls must stay in the `cv()` document body, as the starter does. For standalone composition or for tests, pass `metadata: metadata` explicitly. This alternative is supported, and each applicable component signature documents it.
 
-This ambient behavior is preserved throughout v4 for compatibility. A component used without either explicit metadata or the surrounding `cv()` context now fails with an actionable message at the call site. The state object and underscore-prefixed helpers remain implementation details; a replacement context/factory design belongs in v5 with a migration path.
+v4 keeps this ambient behavior for compatibility. A component with no explicit metadata and no surrounding `cv()` context fails with a clear message at the call site. The state object and the underscore-prefixed helpers are implementation details. A replacement context design, or factory design, belongs in v5 with a migration path.
 
-The supported package-root API is `cv`, `letter`, the nine documented `cv-*` components, `h-bar`, and the compatibility helper `overwrite-fonts`. New templates should configure `[layout.fonts]` rather than call `overwrite-fonts` directly. Dependency symbols such as `fa-*` icons are not re-exported; import them from `fontawesome` directly.
+The supported package-root API is `cv`, `letter`, the nine documented `cv-*` components, `h-bar`, and the compatibility helper `overwrite-fonts`. A new template must configure `[layout.fonts]` and must not call `overwrite-fonts` directly. The package does not re-export dependency symbols such as the `fa-*` icons. Import them from `fontawesome` directly.
 
 ## Entry Point Functions
 
@@ -21,9 +21,9 @@ The supported package-root API is `cv`, `letter`, the nine documented `cv-*` com
 )
 ```
 
-The `cv()` function is the main entry point. It runs schema-migration guards (panic on v3 fields), sets page layout, applies fonts, renders the header, and emits `_cv-footer` on every page. All your CV modules go inside its body.
+The `cv()` function is the main entry point. It operates the schema-migration guards, which panic on v3 fields. It also sets the page layout, applies the fonts, renders the header, and puts `_cv-footer` on every page. All your CV modules go in its body.
 
-By default, `header-info: auto` renders the entries from `metadata.personal.info`. Pass content to replace that row without reimplementing the name, photo, or header layout:
+By default, `header-info: auto` renders the entries from `metadata.personal.info`. To replace that row, pass your own content. The name, the photo, and the header layout do not change:
 
 ```typ
 #import "@preview/brilliant-cv:4.1.0": cv, h-bar
@@ -44,7 +44,7 @@ By default, `header-info: auto` renders the entries from `metadata.personal.info
 
 ![custom header info](assets/components/cv-header-info-custom.png)
 
-Custom content inherits the normal header-info typography and accent color; explicit nested `text(...)` rules can override individual spans. Use `header-info: none` to remove the contact row. The [Custom Header Info](recipes.md#custom-header-info) recipe covers the interaction with metadata and custom icons.
+Your content inherits the normal typography and accent color of the header info. Nested `text(...)` rules can override each span. To remove the contact row, use `header-info: none`. The [Custom Header Info](recipes.md#custom-header-info) recipe describes the interaction with the metadata and with the custom icons.
 
 ### `letter()`
 
@@ -59,7 +59,7 @@ Custom content inherits the normal header-info typography and accent color; expl
 )
 ```
 
-`letter()` mirrors `cv()` for cover-letter pages with letter-formal margins and a 12pt body. `sender-address` defaults to `auto`, which reads `metadata.personal.address` (falls back to `"Your Address Here"` if unset). Use `address-style: "normal"` to disable smallcaps on addresses.
+`letter()` is equivalent to `cv()` for cover-letter pages. It uses formal letter margins and a 12pt body. The default value of `sender-address` is `auto`, which reads `metadata.personal.address`. If that field is not set, the value becomes `"Your Address Here"`. To remove the smallcaps from the addresses, use `address-style: "normal"`.
 
 ---
 
@@ -73,7 +73,7 @@ Custom content inherits the normal header-info typography and accent color; expl
 
 ![cv-section first-letters mode](assets/components/cv-section-first-letters.png)
 
-The default `[layout.section] title_highlight = "first-letters"` highlights the leading 3 chars in the accent color (Latin convention). Override per call with `highlight:` (`"first-letters"` / `"full"` / `"none"`) and `highlight-letters:` (int).
+The default value `[layout.section] title_highlight = "first-letters"` highlights the first 3 characters in the accent color. This is the Latin convention. To override it in one call, use `highlight:` (`"first-letters"`, `"full"`, or `"none"`) and `highlight-letters:` (an integer).
 
 ```typ
 #cv-section("教育背景", highlight: "full")
@@ -81,7 +81,7 @@ The default `[layout.section] title_highlight = "first-letters"` highlights the 
 
 ![cv-section full mode](assets/components/cv-section-full.png)
 
-`"full"` mode colors the entire title — the CJK convention used by `profile_zh`.
+The `"full"` mode colors the complete title. This is the CJK convention, and `profile_zh` uses it.
 
 ```typ
 #cv-section("Education", highlight: "none")
@@ -89,7 +89,7 @@ The default `[layout.section] title_highlight = "first-letters"` highlights the 
 
 ![cv-section none mode](assets/components/cv-section-none.png)
 
-`"none"` keeps the title in body text color — useful for muted, all-monochrome layouts.
+The `"none"` mode keeps the title in the body text color. This is useful for a muted, monochrome layout.
 
 ```typ
 #cv-section("Professional Experience", highlight-letters: 5)
@@ -97,7 +97,7 @@ The default `[layout.section] title_highlight = "first-letters"` highlights the 
 
 ![cv-section 5-letter custom highlight](assets/components/cv-section-custom-letters.png)
 
-`highlight-letters` overrides the default of 3 — handy for short multi-word titles.
+`highlight-letters` overrides the default value of 3. This is useful for a short title with more than one word.
 
 ---
 
@@ -119,7 +119,7 @@ The default `[layout.section] title_highlight = "first-letters"` highlights the 
 
 ![cv-entry with all fields](assets/components/cv-entry-full.png)
 
-The default `[layout.entry] display_entry_society_first = true` puts the company name bold on top, role below. Tags render as pill-style badges.
+The default value `[layout.entry] display_entry_society_first = true` puts the company name in bold on the first line, and the role under it. Tags render as pill-style badges.
 
 ```typ
 #cv-entry(
@@ -133,9 +133,9 @@ The default `[layout.entry] display_entry_society_first = true` puts the company
 
 ![cv-entry without tags](assets/components/cv-entry-no-tags.png)
 
-Omitting `tags:` collapses the tag block entirely (no empty stripe).
+If you omit `tags:`, the tag block collapses completely and leaves no empty stripe.
 
-When `display_entry_society_first = false`, the role becomes the bold anchor and the company moves below — useful for academic or freelance CVs where role hierarchy matters more than employer:
+When `display_entry_society_first = false`, the role becomes the bold anchor and the company moves under it. This is useful for an academic CV or a freelance CV, where the role is more important than the employer:
 
 ![cv-entry role-first layout](assets/components/cv-entry-role-first.png)
 
@@ -143,7 +143,7 @@ When `display_entry_society_first = false`, the role becomes the bold anchor and
 
 ### Multiple Roles at One Company — `cv-entry-start` + `cv-entry-continued`
 
-Use this pair when one person held multiple titles at the same employer:
+When one person had more than one title at the same employer, use this pair of components:
 
 ```typ
 #cv-entry-start(
@@ -165,7 +165,7 @@ Use this pair when one person held multiple titles at the same employer:
 ![cv-entry-start + two continued](assets/components/cv-entry-start-continued.png)
 
 !!! warning
-    Requires `display_entry_society_first = true` in `metadata.toml`. The pair panics with a clear message if the layout is set to role-first — see [`tests/panics/entry-start-needs-society-first`](https://github.com/yunanwg/brilliant-CV/tree/main/tests/panics) for the actual error.
+    This pair needs `display_entry_society_first = true` in `metadata.toml`. If the layout is role-first, the pair panics with a clear message. For the actual error, see [`tests/panics/entry-start-needs-society-first`](https://github.com/yunanwg/brilliant-CV/tree/main/tests/panics).
 
 ---
 
@@ -180,7 +180,7 @@ Use this pair when one person held multiple titles at the same employer:
 
 ![cv-skill basic row](assets/components/cv-skill-basic.png)
 
-The simplest skills row — type label on the left, free-form content on the right. Use `#h-bar()` to separate items with the conventional inline bar.
+This is the most simple skills row. The type label is on the left, and free-form content is on the right. Use `#h-bar()` to separate the items with the conventional inline bar.
 
 ---
 
@@ -196,7 +196,7 @@ The simplest skills row — type label on the left, free-form content on the rig
 
 ![cv-skill-with-level at 5/5](assets/components/cv-skill-with-level-5.png)
 
-Five filled/empty circles render the level. Pass an integer in the range 0–5; the function does not clamp, so a value outside that range will render the wrong number of circles.
+Five circles, filled or empty, show the level. Pass an integer from 0 to 5. The function does not clamp the value, so a value outside that range renders the wrong number of circles.
 
 ---
 
@@ -211,7 +211,7 @@ Five filled/empty circles render the level. Pass an integer in the range 0–5; 
 
 ![cv-skill-tag pill badges](assets/components/cv-skill-tag-basic.png)
 
-Pill-style badges. Useful inside a `cv-skill` info field for certifications or tech stacks where each item deserves visual weight.
+Pill-style badges. These are useful in a `cv-skill` info field, for certifications or tech stacks where each item needs visual weight.
 
 ---
 
@@ -229,7 +229,7 @@ Pill-style badges. Useful inside a `cv-skill` info field for certifications or t
 
 ![cv-honor with link](assets/components/cv-honor-with-url.png)
 
-When `url` is set, the title becomes a clickable link in the rendered PDF. Omit `url` to render the title as plain bold text:
+When you set `url`, the title becomes a clickable link in the PDF. If you omit `url`, the title renders as plain bold text:
 
 ![cv-honor without link](assets/components/cv-honor-no-url.png)
 
@@ -246,7 +246,7 @@ When `url` is set, the title becomes a clickable link in the rendered PDF. Omit 
 )
 ```
 
-Renders a typst `bibliography` object styled to match the rest of the CV. Set `ref-full: true` to show every entry from the bib file; pair `ref-full: false` with `key-list:` to publish only the entries whose keys you want featured. `ref-style:` accepts any [typst bibliography style](https://typst.app/docs/reference/model/bibliography/) (`"apa"`, `"ieee"`, `"chicago-author-date"`, …).
+This component renders a Typst `bibliography` object with the style of the rest of the CV. To show every entry from the bib file, set `ref-full: true`. To show only selected entries, set `ref-full: false` and give their keys in `key-list:`. `ref-style:` accepts any [typst bibliography style](https://typst.app/docs/reference/model/bibliography/), such as `"apa"`, `"ieee"`, or `"chicago-author-date"`.
 
 !!! tip
-    Visual examples for `cv-publication` are not included here — the rendered output depends entirely on your bib file. See [`template/profile_en/publications.typ`](https://github.com/yunanwg/brilliant-CV/blob/main/template/profile_en/publications.typ) for a working example using the bundled `template/assets/publications.bib`.
+    This page has no visual example for `cv-publication`, because the output depends on your bib file. For a working example with the bundled `template/assets/publications.bib`, see [`template/profile_en/publications.typ`](https://github.com/yunanwg/brilliant-CV/blob/main/template/profile_en/publications.typ).

--- a/docs/web/docs/getting-started.md
+++ b/docs/web/docs/getting-started.md
@@ -1,14 +1,14 @@
 # Getting Started — Your First CV in 10 Minutes
 
-## Step 1: Bootstrap
+## Step 1: Initialize the Project
 
-In your local system, bootstrap the template using this command:
+On your local system, create the project with this command:
 
 ```bash
 typst init @preview/brilliant-cv
 ```
 
-Replace the version with the latest or any release (after 2.0.0) if needed:
+To use a specific release, add its version number. All releases after 2.0.0 are supported:
 
 ```bash
 typst init @preview/brilliant-cv:4.1.0
@@ -16,54 +16,54 @@ typst init @preview/brilliant-cv:4.1.0
 
 ## Step 2: Install Fonts
 
-In order to make Typst render correctly, you will have to install the required fonts:
+Install these fonts. Typst needs them to render the CV correctly:
 
 - [Roboto](https://fonts.google.com/specimen/Roboto)
 - [Source Sans 3](https://fonts.google.com/specimen/Source+Sans+3) (or Source Sans Pro)
 - [Font Awesome 7 Free desktop fonts](https://fontawesome.com/download) (Regular, Solid, and Brands OTF files)
 
 For Typst Web, upload the three Font Awesome OTF files to your project. For
-local compilation, install them on your operating system. Without these fonts,
-contact icons render as boxes.
+local compilation, install the same files on your operating system. If these
+fonts are absent, the contact icons render as boxes.
 
 ## Step 3: File Structure Map
 
-After bootstrapping, your project will contain these files:
+After this step, your project contains these files:
 
 | File / Directory | Purpose |
 |-----------------|---------|
-| `cv.typ` | Entry point (edit to add/remove modules) |
+| `cv.typ` | Entry point. Edit it to add or remove modules. |
 | `letter.typ` | Cover letter entry point |
 | `profile_en/metadata.toml` | Complete configuration for the English profile |
-| `profile_en/*.typ` | Your English content modules (edit these) |
-| `profile_<name>/...` | Other profile variants (fr, de, it, zh provided as examples) |
+| `profile_en/*.typ` | Your English content modules. Edit these files. |
+| `profile_<name>/...` | Other profile variants (fr, de, it, and zh are examples) |
 | `assets/` | Your profile photo and logos |
 
 !!! tip
-    Don't edit the package source files under `@preview/brilliant-cv` — they are managed by the Typst package manager.
+    Do not edit the package source files under `@preview/brilliant-cv`. The Typst package manager controls these files.
 
-!!! warning "Keep personal files out of public repos"
-    Many people track their filled-in CV project in a public git repo (see
-    Step 8). Your `assets/` folder ends up holding a real profile photo and,
-    if you use `letter.typ`, a scanned signature — both are sensitive.
-    Consider a private repo, or `.gitignore` the real files and commit
-    placeholders instead.
+!!! warning "Keep personal files out of public repositories"
+    Many people keep their completed CV project in a public git repository
+    (see Step 8). The `assets/` directory then holds a real profile photo. If
+    you use `letter.typ`, it also holds a scanned signature. Both files are
+    sensitive. Use a private repository, or add the real files to
+    `.gitignore` and commit placeholders.
 
 ## Step 4: Configure profile_en/metadata.toml
 
-All customization for the English profile goes through `profile_en/metadata.toml` — it is a **complete, self-contained CV configuration**. See the [Configuration Reference](configuration.md) for the full set of fields.
+You set all options for the English profile in `profile_en/metadata.toml`. This file is a **complete, self-contained CV configuration**. The [Configuration Reference](configuration.md) lists every field.
 
-The most important keys to set first:
+Set these fields first:
 
 - `awesome_color` — your accent color (`"skyblue"`, `"red"`, `"nephritis"`, `"concrete"`, `"darknight"`)
-- `first_name` / `last_name` — your name displayed in the header
-- `[personal.info]` — your contact details (email, phone, GitHub, LinkedIn, etc.)
-- `header_quote` — italic tagline below your name
-- `cv_footer` / `letter_footer` — text shown in the footer
+- `first_name` / `last_name` — your name in the header
+- `[personal.info]` — your contact details (email, phone, GitHub, LinkedIn, and more)
+- `header_quote` — the italic line below your name
+- `cv_footer` / `letter_footer` — the text in the footer
 
 ## Step 5: Add Your First Entry
 
-Open `profile_en/education.typ` and replace its contents with:
+Open `profile_en/education.typ`. Replace its content with this code:
 
 ```typ
 #import "@preview/brilliant-cv:4.1.0": cv-section, cv-entry
@@ -81,7 +81,9 @@ Open `profile_en/education.typ` and replace its contents with:
 )
 ```
 
-Each profile module file (`education.typ`, `professional.typ`, `projects.typ`, `certificates.typ`, `publications.typ`, `skills.typ`) imports from `@preview/brilliant-cv` and emits `cv-*` calls — `cv.typ` includes them in order. Add new sections by creating a new module file under `profile_en/` and adding its name to the `import-modules((...))` call in `cv.typ`.
+Each profile module file imports from `@preview/brilliant-cv` and makes `cv-*` calls. The profile contains these modules: `education.typ`, `professional.typ`, `projects.typ`, `certificates.typ`, `publications.typ`, and `skills.typ`. `cv.typ` includes them in that order.
+
+To add a new section, create a new module file under `profile_en/`. Then add its name to the `import-modules((...))` call in `cv.typ`.
 
 ## Step 6: Compile
 
@@ -91,23 +93,23 @@ typst compile cv.typ
 
 ## Step 7: (Optional) Add More Profiles
 
-If you maintain CVs in multiple languages or for different target roles, copy `profile_en/` to `profile_<name>/` and edit the fields that differ. Each profile is independent — there is no shared root config to coordinate. See [Recipes → Adding a New Profile](recipes.md#adding-a-new-profile) for details.
+If you keep CVs in more than one language, or for different target roles, copy `profile_en/` to `profile_<name>/`. Then edit the fields that are different. Each profile is independent, and there is no shared root configuration. For more information, see [Recipes → Adding a New Profile](recipes.md#adding-a-new-profile).
 
 ## Step 8: Go Beyond
 
-It is recommended to:
+These steps are optional:
 
-1. Use `git` to manage your project — track changes and tag releases of your CV (`git tag cv-v1`, `git tag cv-v2`).
-2. Use [`typstyle`](https://github.com/typstyle-rs/typstyle) and `pre-commit` to keep your `.typ` files consistently formatted.
-3. Use [`typos`](https://github.com/crate-ci/typos) to catch spelling mistakes if your CV is in English.
-4. Wire up CI to compile your CV on every push — see [Recipes → CI/CD with GitHub Actions](recipes.md#cicd-with-github-actions).
+1. Use `git` to manage your project. You can then track changes and tag releases of your CV (`git tag cv-v1`, `git tag cv-v2`).
+2. Use [`typstyle`](https://github.com/typstyle-rs/typstyle) and `pre-commit` to keep the format of your `.typ` files consistent.
+3. If your CV is in English, use [`typos`](https://github.com/crate-ci/typos) to find spelling mistakes.
+4. Configure CI to compile your CV on each push. See [Recipes → CI/CD with GitHub Actions](recipes.md#cicd-with-github-actions).
 
 ## 中文快速上手 (Chinese quickstart)
 
-The template ships `profile_zh/` as a ready-made example — copy it, or copy
-`profile_en/` to `profile_zh/` and edit `metadata.toml`. v4 has no automatic
-"language" mode: fonts, name layout, section styling, and date column width
-are all set explicitly:
+The template contains `profile_zh/` as an example. Copy that directory, or
+copy `profile_en/` to `profile_zh/` and edit `metadata.toml`. v4 has no
+automatic "language" mode. You set the fonts, the name layout, the section
+style, and the width of the date column explicitly:
 
 ```toml
 [personal]
@@ -125,15 +127,15 @@ title_highlight = "full"      # whole title in accent color, not split by codepo
 ```
 
 !!! tip
-    Heiti SC ships only with macOS — elsewhere (and on typst.app) it silently
-    falls back to a different font, changing the look. For cross-platform or
-    typst.app use, swap it for `"Noto Sans CJK SC"` in both font fields above
-    (install it locally, or upload it to your typst.app project).
+    Heiti SC is available only on macOS. On other systems, and on typst.app,
+    Typst falls back to a different font and the result looks different. For
+    other systems, or for typst.app, use `"Noto Sans CJK SC"` in the two font
+    fields. Install that font locally, or upload it to your typst.app project.
 
-Compile with the profile flag:
+Compile the CV with the profile input:
 
 ```bash
 typst compile cv.typ --input profile=zh
 ```
 
-See [Troubleshooting → Non-Latin Characters](troubleshooting.md#non-latin-characters-showing-as-boxes) if characters render as boxes.
+If the characters render as boxes, see [Troubleshooting → Non-Latin Characters](troubleshooting.md#non-latin-characters-showing-as-boxes).

--- a/docs/web/docs/index.md
+++ b/docs/web/docs/index.md
@@ -4,21 +4,21 @@
 [![License](https://img.shields.io/badge/license-Apache_2.0-green.svg)](https://github.com/yunanwg/brilliant-CV/blob/main/LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/yunanwg/brilliant-CV?color=orange)](https://github.com/yunanwg/brilliant-CV/releases)
 
-A modern, modular, and feature-rich CV template for [Typst](https://typst.app).
+A modern, modular CV template for [Typst](https://typst.app).
 
 ![brilliant-CV Preview](https://github.com/mintyfrankie/mintyfrankie/assets/77310871/94f5fb5c-03d0-4912-b6d6-11ee7d27a9a3){ width="100%" }
 
 !!! info "🆕 v4 is a breaking change"
-    Coming from v3? See the [Migration Guide](migration.md) for the v3 → v4 panic-with-migration-message guards (`language`, `non_latin_font`, `[lang.<code>]`, `inject_ai_prompt`, …) and their v4 replacements.
+    If you come from v3, read the [Migration Guide](migration.md). When v4 finds a removed v3 field (`language`, `non_latin_font`, `[lang.<code>]`, `inject_ai_prompt`, and more), it panics with a migration message. The guide gives the v4 replacement for each one.
 
 ## Features
 
-- **Separation of Style & Content** — Write your CV entries in simple Typst files; the template handles layout and styling.
-- **Profile-based Variants** — Each `profile_<name>/` is a complete, self-contained CV. Switch with `--input profile=fr` at compile time. No language whitelist; any script (CJK, Arabic, Hebrew, …) is configurable explicitly via `[layout.fonts]`.
-- **Optional ATS Keyword Injection** — Opt-in hidden keyword text for automated screeners, marked as a PDF artifact so screen readers skip it. Off by default — some screening systems detect and penalize hidden text; see the `[inject]` notes in `metadata.toml` before enabling.
-- **Highly Customizable** — Tweak colors, fonts, layout, and section highlights via per-profile `metadata.toml` files.
-- **Pixel-perfect Tested** — 40+ tests (panic, unit, component, regression) run inside a Linux Docker baseline so refs are deterministic. Layout regressions can't slip past CI.
-- **Zero-Setup** — Get started in seconds with the Typst CLI.
+- **Separation of Style & Content** — You write your CV entries in simple Typst files. The package applies the layout and the style.
+- **Profile-based Variants** — Each `profile_<name>/` directory is one complete CV. To select a profile at compile time, use `--input profile=fr`. There is no language whitelist. You configure any script (CJK, Arabic, Hebrew, and more) explicitly in `[layout.fonts]`.
+- **Optional ATS Keyword Injection** — The package can add hidden keyword text for automated screeners. It marks this text as a PDF artifact, so screen readers skip it. The function is off by default, because some screening systems find hidden text and penalize it. Read the `[inject]` notes in `metadata.toml` before you enable it.
+- **Highly Customizable** — You set colors, fonts, layout, and section highlights in the `metadata.toml` file of each profile.
+- **Pixel-perfect Tested** — More than 40 tests (panic, unit, component, regression) run in a Linux Docker baseline. The refs are deterministic, so CI catches every layout regression.
+- **Zero-Setup** — The Typst CLI creates a new project with one command.
 
 ## Quick Install
 
@@ -44,25 +44,25 @@ typst init @preview/brilliant-cv
 
 -   :material-rocket-launch: __Build your first CV in 10 minutes__
 
-    Bootstrap a project, edit a profile, compile to PDF.
+    Create a project, edit a profile, and compile it to PDF.
 
     [:octicons-arrow-right-24: Getting Started](getting-started.md)
 
 -   :material-puzzle: __Explore the components__
 
-    Every `cv-*` building block with copy-pasteable examples.
+    Every `cv-*` building block, with examples that you can copy.
 
     [:octicons-arrow-right-24: Components](components.md)
 
 -   :material-book-open-variant: __Common recipes__
 
-    Profile photos, custom icons, color presets, CI/CD, multi-profile setups.
+    Profile photos, custom icons, color presets, CI/CD, and multi-profile projects.
 
     [:octicons-arrow-right-24: Recipes](recipes.md)
 
 -   :material-cog: __Configuration reference__
 
-    Every `metadata.toml` field, live-included from `profile_en/`.
+    Every `metadata.toml` field, included directly from `profile_en/`.
 
     [:octicons-arrow-right-24: Configuration](configuration.md)
 
@@ -74,7 +74,7 @@ typst init @preview/brilliant-cv
 
 -   :material-package-up: __Migrating from v1 / v2 / v3?__
 
-    The v3 → v4 panic-with-migration guards and their replacements.
+    The v3 to v4 migration guards and their replacements.
 
     [:octicons-arrow-right-24: Migration Guide](migration.md)
 

--- a/docs/web/docs/migration.md
+++ b/docs/web/docs/migration.md
@@ -2,29 +2,29 @@
 
 ## Migration from v3
 
-v4 introduces a **profile-based** architecture: each CV variant lives in its own `profile_<name>/` directory with a self-contained `metadata.toml` and content modules. This solves [#142](https://github.com/yunanwg/brilliant-CV/issues/142) — you can now vary *any* field per profile (`[personal.info]`, `[layout]`, `[inject]`, the lot), not just the three localized strings v3 supported via `[lang.<code>]`.
+v4 has a **profile-based** architecture. Each CV variant is in its own `profile_<name>/` directory, with a self-contained `metadata.toml` and its content modules. This corrects [#142](https://github.com/yunanwg/brilliant-CV/issues/142). You can now change *any* field for each profile, which includes `[personal.info]`, `[layout]`, and `[inject]`. v3 supported only the three localized strings in `[lang.<code>]`.
 
 ### Design principles
 
-- **One profile = one complete CV configuration.** Look at a single `profile_<name>/metadata.toml` and you see the full effective config for that profile — no merging, no inheritance.
-- **No root `metadata.toml`.** The v4 template ships only profile directories; there is no shared/base config layer.
-- **DRY is the user's job, not the framework's.** If you maintain many profiles and want to share config, you can add your own preprocessor or symlinks; the package stays simple.
+- **One profile is one complete CV configuration.** A single `profile_<name>/metadata.toml` shows the full effective configuration for that profile. There is no merge and no inheritance.
+- **No root `metadata.toml`.** The v4 template contains only profile directories. There is no shared base configuration layer.
+- **DRY is the work of the user, not of the package.** To share configuration between many profiles, you can add your own preprocessor or symlinks. The package stays simple.
 
 ### Upgrade steps
 
-**1. Rename your module folder to a profile folder:**
+**1. Rename your module directory to a profile directory:**
 
 ```
 modules_en/  →  profile_en/
 ```
 
-**2. Move your `metadata.toml` into the profile folder and flatten the schema:**
+**2. Move your `metadata.toml` into the profile directory and flatten the schema:**
 
 ```
 metadata.toml  →  profile_en/metadata.toml
 ```
 
-You also need to flatten the v3 `[lang.<code>]` structure to top-level fields. v4 panics on detection of any v3-only schema field (consistent with the existing v2→v3 `inject_*` migration guards) — see "Schema migration guards" below for the exact field mapping.
+You must also flatten the v3 `[lang.<code>]` structure to top-level fields. When v4 finds a v3-only schema field, it panics. This is the same behavior as the v2 to v3 `inject_*` migration guards. For the exact field mapping, see "Schema migration guards".
 
 **3. Update your `cv.typ`:**
 
@@ -64,23 +64,23 @@ You also need to flatten the v3 `[lang.<code>]` structure to top-level fields. v
 typst compile cv.typ --input profile=fr
 ```
 
-**6. Adding more profiles.** Copy `profile_en/` to `profile_<new>/` and edit the fields that differ. Each profile is independent — there's no DRY mechanism inside the package, by design.
+**6. Add more profiles.** Copy `profile_en/` to `profile_<new>/`. Then edit the fields that are different. Each profile is independent. The package has no DRY mechanism, and this is intentional.
 
 See [Recipes → Switching Profiles](recipes.md#switching-profiles-at-compile-time) for compile-time examples.
 
 ### Schema migration guards (panic on v3 fields)
 
-v4 follows the same pattern the package already used for the v2→v3 `inject_ai_prompt` / `inject_keywords` migration: when a removed v3 schema field is detected at compile time, the package **panics with a migration message** rather than silently falling back. This avoids the "silent fallback" anti-pattern that hides behavior changes.
+v4 uses the same pattern as the v2 to v3 migration of `inject_ai_prompt` and `inject_keywords`. When the package finds a removed v3 schema field at compile time, it **panics with a migration message**. It does not fall back silently. A silent fallback is an anti-pattern, because it hides a change of behavior.
 
 The guarded fields and their replacements:
 
 | v3 field | Panic? | v4 replacement |
 |---|---|---|
 | `language` | ✅ | Set typography explicitly: `[layout.fonts] regular_fonts`, `[layout.fonts] header_font`, `[layout.section] title_highlight`, `[personal] display_name`, `[layout] date_width` |
-| `non_latin_font` | ✅ | List both fonts in `[layout.fonts] regular_fonts = ["Source Sans 3", "Heiti SC"]` and set `[layout.fonts] header_font`. typst's codepoint-level fallback handles mixed scripts — verified empirically (`pdffonts` shows identical embedded subsets to the v3 trigger). |
-| `non_latin_name` | ✅ | `[personal] display_name` — overrides the Latin first/last split with a single styled string |
+| `non_latin_font` | ✅ | List both fonts in `[layout.fonts] regular_fonts = ["Source Sans 3", "Heiti SC"]` and set `[layout.fonts] header_font`. Typst selects the font for each codepoint, so mixed scripts work. A test with `pdffonts` shows the same embedded subsets as the v3 trigger. |
+| `non_latin_name` | ✅ | `[personal] display_name`. It replaces the Latin split of first name and last name with one styled string. |
 | `[lang.<code>]` table | ✅ | Set `header_quote`, `cv_footer`, `letter_footer` as top-level fields in `profile_<name>/metadata.toml` |
-| `[lang.non_latin]` table | ✅ (covered by `[lang.*]` panic above) | Use `[personal] display_name` and `[layout.fonts]` |
+| `[lang.non_latin]` table | ✅ (the `[lang.*]` panic in the previous row covers it) | Use `[personal] display_name` and `[layout.fonts]` |
 
 #### v3 (`language=zh`) → v4 example
 
@@ -118,21 +118,21 @@ title_highlight = "full"
 display_name = "王道尔"
 ```
 
-The `_is-non-latin()` whitelist and `_default-date-width()` lookup table are gone from `src/utils/lang.typ` (file deleted). Adding a new non-Latin script (Arabic, Hebrew, Thai, Devanagari, …) no longer requires a framework change — users configure typography directly.
+v4 removes the file `src/utils/lang.typ`, with its `_is-non-latin()` whitelist and its `_default-date-width()` lookup table. A new non-Latin script (Arabic, Hebrew, Thai, Devanagari, and more) no longer needs a change to the package. Users configure the typography directly.
 
 ### Why panic instead of silent fallback?
 
-The package supports three backward-compat patterns. v4 deliberately picks **panic-with-migration-message** for schema changes:
+The package has three patterns for backward compatibility. For schema changes, v4 uses **panic with a migration message**:
 
 | Pattern | When used | Example |
 |---|---|---|
 | **Panic with migration message** | Removed metadata schema fields | `inject_ai_prompt`, v3 `language` / `non_latin_*` / `[lang.*]` |
 | **Fully removed** | Renamed function/parameter aliases | `cvEntry`, `profilePhoto`, `awesomeColors` (typst gives a generic "unknown parameter" error) |
-| **Silent fallback** | ❌ Avoided in v4 — was used briefly for v3 metadata fields and removed because hidden behavior changes broke the "explicit > implicit" design |
+| **Silent fallback** | ❌ Not used in v4. v3 metadata fields used it for a short time. v4 removed it, because a hidden change of behavior broke the "explicit > implicit" design. |
 
 ### Removed in v4 (no longer panic — fully removed)
 
-The following parameter aliases and function aliases have **panicked since v3** and are now **removed entirely** in v4. Code still using them will fail with a generic "unknown parameter" / "unknown function" error rather than the v3 deprecation panic.
+These parameter aliases and function aliases **panicked in v3**. v4 **removes them completely**. Code that still uses them fails with a generic "unknown parameter" or "unknown function" error, not with the v3 deprecation panic.
 
 **Parameter aliases (now removed):**
 
@@ -149,17 +149,17 @@ The following parameter aliases and function aliases have **panicked since v3** 
 
 **Function aliases (now removed):**
 
-`cvEntry`, `cvEntryStart`, `cvEntryContinued`, `cvSection`, `cvSkill`, `cvSkillWithLevel`, `cvSkillTag`, `cvHonor`, `cvPublication`, `hBar` — use the kebab-case equivalents.
+`cvEntry`, `cvEntryStart`, `cvEntryContinued`, `cvSection`, `cvSkill`, `cvSkillWithLevel`, `cvSkillTag`, `cvHonor`, `cvPublication`, and `hBar`. Use the kebab-case names.
 
-**Schema migration guards retained:** `inject_ai_prompt` and `inject_keywords` still panic with a clear upgrade message if found in `metadata.toml`. These are kept because silently ignoring an unknown metadata key would be confusing — a user who sees their ATS keywords disappear should know why.
+**Schema migration guards kept:** if `metadata.toml` contains `inject_ai_prompt` or `inject_keywords`, the package still panics with a clear upgrade message. A silent ignore of an unknown metadata key is confusing. A user whose ATS keywords disappear must know the cause.
 
 ### Supported root exports in v4
 
 The supported package-root API consists of `cv`, `letter`, `cv-section`, `cv-entry`, `cv-entry-start`, `cv-entry-continued`, `cv-skill`, `cv-skill-with-level`, `cv-skill-tag`, `cv-honor`, `cv-publication`, `h-bar`, and `overwrite-fonts`.
 
-`overwrite-fonts` remains explicit for v4 compatibility because older wildcard imports made it reachable. New templates should configure `[layout.fonts]` and let `cv()` or `letter()` resolve fonts; reconsidering the helper belongs in v5.
+`overwrite-fonts` stays in the API for v4 compatibility, because older wildcard imports made it reachable. In a new template, configure `[layout.fonts]` and let `cv()` or `letter()` resolve the fonts. A new decision about this helper belongs in v5.
 
-Older releases also exposed dependency symbols such as `fa-*` icons and internal state through wildcard imports. Those were never documented compatibility commitments and are no longer re-exported. Import icons from Font Awesome directly:
+Older releases also made dependency symbols available through wildcard imports, such as the `fa-*` icons and the internal state. These symbols were never documented compatibility commitments, and the package no longer re-exports them. Import the icons from Font Awesome directly:
 
 ```typ
 #import "@preview/fontawesome:0.6.2": fa-github
@@ -169,11 +169,11 @@ Older releases also exposed dependency symbols such as `fa-*` icons and internal
 
 ## Migration from v2
 
-v3 introduces a new directory structure, kebab-case naming, and removes several deprecated features. If you are upgrading from v2, follow these steps.
+v3 has a new directory structure and kebab-case names. It also removes several deprecated features. If you upgrade from v2, do these steps.
 
 ### 1. Update Imports
 
-The package entry point is unchanged, but you should update any version-pinned imports:
+The package entry point does not change. Update each version-pinned import:
 
 ```typ
 // Before (v2)
@@ -185,7 +185,7 @@ The package entry point is unchanged, but you should update any version-pinned i
 
 ### 2. Parameter Renaming (now panics)
 
-In v3, all camelCase parameter aliases **panic at compile time** instead of silently mapping to the new names. Update all call sites:
+In v3, all camelCase parameter aliases **panic at compile time**. They do not map silently to the new names. Update every call site:
 
 | Old (v2, camelCase) | New (v3, kebab-case) | Function |
 |---------------------|----------------------|----------|
@@ -193,14 +193,14 @@ In v3, all camelCase parameter aliases **panic at compile time** instead of sile
 | `myAddress` | `sender-address` | `letter()` |
 | `recipientName` | `recipient-name` | `letter()` |
 | `recipientAddress` | `recipient-address` | `letter()` |
-| `awesomeColors` | `awesome-colors` | `cv-section`, `cv-entry`, `cv-honor`, etc. |
+| `awesomeColors` | `awesome-colors` | `cv-section`, `cv-entry`, `cv-honor`, and more |
 | `refStyle` | `ref-style` | `cv-publication` |
 | `refFull` | `ref-full` | `cv-publication` |
 | `keyList` | `key-list` | `cv-publication` |
 
 ### 3. Removed Function Aliases (now panic)
 
-The old camelCase function names now panic immediately. Rename all usages:
+The old camelCase function names now panic immediately. Rename every use:
 
 | Old (v2) | New (v3) |
 |----------|----------|
@@ -217,7 +217,7 @@ The old camelCase function names now panic immediately. Rename all usages:
 
 ### 4. Removed `[inject]` Keys (now panic)
 
-The old injection keys have been removed. If your `metadata.toml` still contains them, the CV will panic:
+v3 removes the old injection keys. If your `metadata.toml` still contains them, the CV panics:
 
 ```toml
 # Before (v2) — these now cause panics
@@ -232,35 +232,35 @@ injected_keywords_list = ["Python", "SQL"]
 # custom_ai_prompt_text = "Optional custom prompt"
 ```
 
-- `inject_keywords` has been removed — if `injected_keywords_list` is present, keywords are injected automatically
-- `inject_ai_prompt` has been removed — use `custom_ai_prompt_text` instead
+- `inject_keywords` is removed. If `injected_keywords_list` is present, the package injects the keywords automatically.
+- `inject_ai_prompt` is removed. Use `custom_ai_prompt_text`.
 
 ### 5. Template Updates
 
-If you are using the template, update your `cv.typ` and `letter.typ` to use the new parameter names. See the [API Reference](api-reference.md) for the current signatures.
+If you use the template, update `cv.typ` and `letter.typ` with the new parameter names. For the current signatures, see the [API Reference](api-reference.md).
 
 ---
 
 ## Migration from v1
 
 !!! note
-    The version v1 is now deprecated, due to the compliance to Typst Packages standard. However, if you want to continue to develop on the older version, please refer to the `v1-legacy` branch.
+    Version v1 is deprecated, because the package now obeys the Typst Packages standard. To continue work on the older version, use the `v1-legacy` branch.
 
-With an existing CV project using the v1 version of the template, a migration is needed, including replacing some files and some content in certain files.
+An existing CV project that uses v1 needs a migration. You must replace some files, and some content in other files.
 
-1. **Delete old submodule** — Remove the `brilliant-CV` folder and `.gitmodules`. Future package management is handled directly by Typst.
+1. **Remove the old submodule** — Remove the `brilliant-CV` directory and `.gitmodules`. Typst now does the package management.
 
-2. **Migrate metadata** — Migrate all the config from `metadata.typ` by creating a new `metadata.toml`. Follow the example TOML file in the repo — it is rather straightforward to migrate.
+2. **Migrate the metadata** — Create a new `metadata.toml` and move all the configuration from `metadata.typ` into it. Use the example TOML file in the repository as a model.
 
-3. **Update entry points** — For `cv.typ` and `letter.typ`, copy the new files from the repo, and adapt the modules you have in your project.
+3. **Update the entry points** — Copy the new `cv.typ` and `letter.typ` from the repository. Then adapt them to the modules in your project.
 
 4. **Update module files** in `modules_*/`:
-    1. Delete the old import `#import "../brilliant-CV/template.typ": *`, and replace it with the import statements from the new template files.
-    2. Due to the Typst path handling mechanism, one cannot directly pass the path string to some functions anymore. This concerns, for example, the `logo` argument in `cv-entry`, but also `cv-publication` as well. Some parameter names were changed, but most importantly, **you should pass a function instead of a string** (i.e. `image("logo.png")` instead of `"logo.png"`). Refer to the new template files for reference.
+    1. Remove the old import `#import "../brilliant-CV/template.typ": *`. Replace it with the import statements from the new template files.
+    2. Typst changed its path handling, so some functions no longer accept a path string. This applies to the `logo` argument in `cv-entry` and to `cv-publication`. Some parameter names also changed. **Pass a function, not a string.** For example, use `image("logo.png")` in place of `"logo.png"`. For more information, see the new template files.
 
-5. **Install fonts** — You might need to install `FontAwesome 6`, `Roboto` and `Source Sans Pro` on your local system now, as new Typst package guidelines discourage including these large files.
+5. **Install the fonts** — You can need `FontAwesome 6`, `Roboto`, and `Source Sans Pro` on your local system. The new Typst package guidelines are against the inclusion of these large files in a package.
 
-6. **Compile** — Run `typst compile cv.typ` without passing the `font-path` flag. All should be good now — congrats!
+6. **Compile** — Run `typst compile cv.typ`. Do not use the `font-path` flag. The migration is then complete.
 
 !!! tip
-    Feel free to [raise an issue](https://github.com/yunanwg/brilliant-CV/issues) for more assistance should you encounter a problem that you cannot solve on your own.
+    If you have a problem that you cannot solve, [raise an issue](https://github.com/yunanwg/brilliant-CV/issues).

--- a/docs/web/docs/recipes.md
+++ b/docs/web/docs/recipes.md
@@ -2,8 +2,8 @@
 
 ## Adding a New Module
 
-1. Create a new file, e.g. `profile_en/volunteering.typ`
-2. Add your imports and content (sections, entries, etc.)
+1. Create a new file, for example `profile_en/volunteering.typ`
+2. Add your imports and your content (sections, entries, and more)
 3. In `cv.typ`, add `"volunteering"` to the `import-modules` call
 
 ## Switching Profiles at Compile Time
@@ -12,39 +12,41 @@
 typst compile cv.typ --input profile=fr
 ```
 
-The `profile` input picks which `profile_<name>/` directory to load. For non-Latin scripts (Chinese, Japanese, Korean, Russian, Arabic, …), configure typography explicitly in `[layout.fonts]` (font fallback chain), `[layout.section]` (title highlighting), and `[personal] display_name`. See `template/profile_zh/metadata.toml` for a complete example.
+The `profile` input selects the `profile_<name>/` directory to load. For a non-Latin script (Chinese, Japanese, Korean, Russian, Arabic, and more), configure the typography explicitly. Set the font fallback chain in `[layout.fonts]`, the title highlight in `[layout.section]`, and the name in `[personal] display_name`. For a complete example, see `template/profile_zh/metadata.toml`.
 
 ## Adding a New Profile
 
-Each profile is **self-contained** — one `profile_<name>/metadata.toml` holds the complete CV configuration for that variant. To add a new profile (e.g. a Swedish CV):
+Each profile is **self-contained**. One `profile_<name>/metadata.toml` holds the complete CV configuration for that variant. To add a new profile, for example a Swedish CV, do these steps:
 
 1. Copy an existing profile directory:
     ```bash
     cp -r template/profile_en template/profile_swe
     ```
-2. Edit `profile_swe/metadata.toml` — change `header_quote`, `cv_footer`, `letter_footer`, and any other fields that differ from English.
+2. Edit `profile_swe/metadata.toml`. Change `header_quote`, `cv_footer`, `letter_footer`, and each other field that is different from English.
 3. Edit the `.typ` modules under `profile_swe/` for Swedish content.
 4. Compile with `typst compile cv.typ --input profile=swe`.
 
-There is no shared root metadata or merge mechanism in v4. **Profile = a complete CV config**; copy-paste is the way to start a new one.
+v4 has no shared root metadata and no merge mechanism. **One profile is one complete CV configuration.** To start a new profile, copy an existing one.
 
 ### Profile ≠ language
 
-The profile name is just a directory suffix — it doesn't carry semantic meaning to the package. You can have `profile_us/` and `profile_uk/` (both English text, different locations / phone numbers / layouts) sitting next to `profile_zh/` (Chinese with Heiti SC); each profile's `metadata.toml` is independently complete. Pick whatever directory names make sense for your variants.
+The profile name is only a directory suffix. It has no meaning for the package. For example, you can keep `profile_us/` and `profile_uk/` next to `profile_zh/`. The first two hold English text with different locations, phone numbers, and layouts. The third holds Chinese text with Heiti SC.
 
-### Sharing config across profiles
+The `metadata.toml` of each profile is complete on its own. Select the directory names that are correct for your variants.
 
-If you maintain many profiles and want to share fields (GitHub username, layout colors, etc.), the package itself does not provide a merge mechanism. Common user-side options:
+### Sharing configuration across profiles
 
-- **A small Python/shell preprocessor** that reads a canonical base + per-profile overrides and writes the profile `metadata.toml` files at build time.
-- **`typstyle`-friendly hand-edits** — for 2-3 profiles, manual sync is usually fine.
-- **Symlinks or `git rerere`** to keep selected fields in sync.
+The package has no merge mechanism for shared fields, such as a GitHub username or the layout colors. If you keep many profiles, these options are available to you:
 
-The framework keeps "one profile = one file" so your tooling stays free.
+- **A small Python or shell preprocessor.** It reads a canonical base and the overrides of each profile, then writes the profile `metadata.toml` files at build time.
+- **`typstyle`-friendly manual edits.** For 2 or 3 profiles, manual synchronization is usually sufficient.
+- **Symlinks or `git rerere`** to keep the selected fields synchronized.
+
+The package keeps one profile in one file, so you can select your own tools.
 
 ## Skills with Inline Separators
 
-Use `#h-bar()` to separate skill items within `cv-skill`:
+Use `#h-bar()` to separate the skill items in `cv-skill`:
 
 ```typ
 #cv-skill(
@@ -55,9 +57,9 @@ Use `#h-bar()` to separate skill items within `cv-skill`:
 
 ## Verification Links and Richer Certificate Metadata
 
-`cv-honor` is intentionally compact: it ships with `date`, `title`, `issuer`, `url`, and `location` — no free-form description slot. Pick the right component based on what you need to surface.
+`cv-honor` is compact. It has `date`, `title`, `issuer`, `url`, and `location`, but it has no free-form description field. Select the component that shows the data you need.
 
-**Just a clickable verification link** — pass the verification URL as `url`. The title becomes a link; `location` is a good place for short status text:
+**For a clickable verification link only**, pass the verification URL as `url`. The title becomes a link. Put short status text in `location`:
 
 ```typ
 #cv-honor(
@@ -69,7 +71,7 @@ Use `#h-bar()` to separate skill items within `cv-skill`:
 )
 ```
 
-**Credential ID, expiry, multiple links** — switch to `cv-entry`, which has a content-flexible `description` field. The trade-off is a slightly heavier visual footprint, but you get full formatting freedom:
+**For a credential ID, an expiry date, or more than one link**, use `cv-entry`. Its `description` field accepts any content. This component uses more space on the page, but it gives you full control of the format:
 
 ```typ
 #cv-entry(
@@ -84,11 +86,11 @@ Use `#h-bar()` to separate skill items within `cv-skill`:
 )
 ```
 
-The two components are interchangeable inside a `Certificates` section; mix them per entry depending on whether you need the compact one-line layout or the richer description block.
+You can use the two components together in one `Certificates` section. For each entry, select `cv-honor` for the compact one-line layout, or `cv-entry` for the larger description block.
 
 ## Adding a Profile Photo
 
-The profile photo is passed as an argument to `cv()` in your `cv.typ`, not set in `metadata.toml`:
+You pass the profile photo as an argument to `cv()` in your `cv.typ`. You do not set it in `metadata.toml`:
 
 ```typ
 #show: cv.with(
@@ -103,11 +105,11 @@ Control the shape with `profile_photo_radius` in `[layout.header]`:
 - `"0%"` — square
 - `"10%"` — rounded corners
 
-Set `display_profile_photo = false` in `[layout.header]` to hide the photo entirely.
+To hide the photo, set `display_profile_photo = false` in `[layout.header]`.
 
 ## Custom Contact Icon with Image
 
-To add a custom contact entry with an image icon (instead of a Font Awesome icon):
+To add a custom contact entry with an image icon in place of a Font Awesome icon, do these steps:
 
 1. Define the entry in `metadata.toml` with an `awesomeIcon` fallback:
 
@@ -118,7 +120,7 @@ To add a custom contact entry with an image icon (instead of a Font Awesome icon
     link = "https://example.com"
     ```
 
-2. Pass the image in `cv.typ` via the `custom-icons` parameter (the key must match `custom-1`):
+2. Pass the image in `cv.typ` with the `custom-icons` parameter. The key must agree with `custom-1`:
 
     ```typ
     #show: cv.with(
@@ -130,11 +132,11 @@ To add a custom contact entry with an image icon (instead of a Font Awesome icon
     )
     ```
 
-When a `custom-icons` entry is provided, it takes priority over the `awesomeIcon` value from TOML.
+If you give a `custom-icons` entry, it has priority over the `awesomeIcon` value from the TOML file.
 
 ## Custom Header Info
 
-The default header turns `[personal.info]` entries into linked contact items, inserts icons, and places `h-bar()` between them automatically. When you need precise control over separators, line breaks, or which spans use the accent color, pass custom content through `header-info`:
+The default header makes a linked contact item from each `[personal.info]` entry. It adds the icons and puts `h-bar()` between the items automatically. You can also control the separators, the line breaks, and the accent color of each span. To do this, pass your own content in `header-info`:
 
 ```typ
 #import "@preview/brilliant-cv:4.1.0": cv, h-bar
@@ -154,9 +156,9 @@ The default header turns `[personal.info]` entries into linked contact items, in
 )
 ```
 
-The replacement inherits the default header-info font size and accent color. Style individual spans explicitly to override those defaults. Because the replacement bypasses automatic `[personal.info]` rendering, add any desired icons and links directly in the content; `custom-icons` only applies to the default `auto` renderer.
+Your content inherits the default font size and accent color of the header info. To override these defaults, style each span explicitly. Your content also replaces the automatic rendering of `[personal.info]`. Add the icons and the links that you want directly in the content. `custom-icons` applies only to the default `auto` renderer.
 
-Use a function when that keeps your template clearer, but call it before passing the result—the API accepts the resulting content rather than a renderer callback:
+You can use a function to make your template clearer. Call the function first, then pass its result. The API accepts content, not a renderer callback:
 
 ```typ
 #let render-info(info) = [#info.email #h-bar() #info.location]
@@ -167,13 +169,13 @@ Use a function when that keeps your template clearer, but call it before passing
 )
 ```
 
-Pass `header-info: none` to remove the contact row while keeping the name, optional quote, photo, and surrounding layout intact.
+To remove the contact row, pass `header-info: none`. The name, the optional quote, the photo, and the rest of the layout do not change.
 
 ## Color Customization
 
 ### Preset Colors
 
-Set `awesome_color` in `[layout]` to one of the built-in presets:
+Set `awesome_color` in `[layout]` to one of these presets:
 
 | Name | Hex |
 |------|-----|
@@ -190,7 +192,7 @@ awesome_color = "nephritis"
 
 ### Custom Hex Color
 
-Pass any hex color string directly:
+You can also set any hex color string directly:
 
 ```toml
 [layout]
@@ -223,11 +225,11 @@ Dear Hiring Manager,
 Sincerely,
 ```
 
-Leave `signature` as `""` (default) to omit the signature image.
+To omit the signature image, leave `signature` as `""`. This is the default value.
 
 ## CI/CD with GitHub Actions
 
-A minimal workflow to compile your CV on every push:
+This is a minimal workflow that compiles your CV on each push:
 
 ```yaml
 name: Build CV
@@ -254,4 +256,4 @@ jobs:
 ```
 
 !!! tip
-    If your CV uses custom fonts, add a step to install them before compiling. See the [Troubleshooting](troubleshooting.md) page for font issues.
+    If your CV uses custom fonts, add a step that installs them before the compile step. For font problems, see the [Troubleshooting](troubleshooting.md) page.

--- a/docs/web/docs/troubleshooting.md
+++ b/docs/web/docs/troubleshooting.md
@@ -6,7 +6,7 @@ Paths in module files are relative to the module file itself, not the project ro
 
 ## Font Missing
 
-Install Roboto and Source Sans 3 (or Source Sans Pro) locally. For non-Latin profiles, install the font(s) listed in `[layout.fonts] regular_fonts` and `[layout.fonts] header_font` for that profile (e.g. "Heiti SC" for Chinese on macOS, or "Noto Sans CJK SC" as a freely-redistributable alternative).
+Install Roboto and Source Sans 3 (or Source Sans Pro) locally. For a non-Latin profile, install each font that `[layout.fonts] regular_fonts` and `[layout.fonts] header_font` name for that profile. For example, Chinese on macOS uses "Heiti SC". "Noto Sans CJK SC" is a freely-redistributable alternative.
 
 ## Icons Render as Boxes
 
@@ -16,33 +16,33 @@ Contact icons use the Font Awesome desktop fonts. Download the
 - In Typst Web, upload the Regular, Solid, and Brands OTF files to your project.
 - For local compilation, install the same OTF files on your operating system.
 
-Recompile after adding the fonts. The package provides the icon mappings, but
-does not bundle the font files themselves.
+After you add the fonts, compile the CV again. The package contains the icon
+mappings, but it does not contain the font files.
 
 ## h-bar() Not Working
 
-Make sure you import `h-bar` from the package:
+Make sure that you import `h-bar` from the package:
 
 ```typ
 #import "@preview/brilliant-cv:4.1.0": h-bar
 ```
 
-The old name `hBar` has been removed in v3. See the [Migration Guide](migration.md) for all renamed functions.
+v3 removed the old name `hBar`. See the [Migration Guide](migration.md) for all renamed functions.
 
 ## Wrong metadata.toml Key Silently Ignored
 
-Typst TOML parsing doesn't warn on unknown keys. Double-check key names against the [Configuration Reference](configuration.md). Common mistakes: `headerAlign` (wrong) vs `header_align` (correct).
+Typst gives no warning for an unknown key in a TOML file. Make sure that each key name agrees with the [Configuration Reference](configuration.md). A common error is `headerAlign`. The correct key is `header_align`.
 
 ## New Module Not Appearing
 
-After creating a new module file, you must add its name to the `import-modules((...))` call in `cv.typ`.
+After you create a new module file, you must add its name to the `import-modules((...))` call in `cv.typ`.
 
 ## Profile Photo Not Showing
 
-Check two things:
+Make sure that these two conditions are true:
 
 1. `display_profile_photo` must be `true` in `[layout.header]` of your `metadata.toml`
-2. The photo is passed as an argument in `cv.typ`, **not** set in `metadata.toml`:
+2. You pass the photo as an argument in `cv.typ`. You do **not** set it in `metadata.toml`:
 
 ```typ
 #show: cv.with(
@@ -51,14 +51,14 @@ Check two things:
 )
 ```
 
-The image path is relative to the `cv.typ` file. If your photo is in a different directory, adjust the path accordingly.
+The image path is relative to the `cv.typ` file. If your photo is in a different directory, change the path.
 
 ## Non-Latin Characters Showing as Boxes
 
-If Chinese, Japanese, Korean, Russian, Arabic, etc. characters render as empty boxes or tofu:
+If Chinese, Japanese, Korean, Russian, Arabic, or other non-Latin characters render as empty boxes (also called tofu), do these steps:
 
-1. **Install the appropriate font on your system** (e.g. "Heiti SC" for Chinese on macOS; "Noto Sans CJK SC" on Linux is a freely-redistributable alternative).
-2. **List both Latin and non-Latin fonts in `[layout.fonts] regular_fonts`** — typst's codepoint-level fallback picks per character, so a single font chain handles mixed scripts:
+1. **Install the correct font on your system.** For example, Chinese on macOS uses "Heiti SC". On Linux, "Noto Sans CJK SC" is a freely-redistributable alternative.
+2. **List the Latin fonts and the non-Latin fonts in `[layout.fonts] regular_fonts`.** Typst selects the font for each codepoint, so one font chain is sufficient for mixed scripts:
 
     ```toml
     [layout.fonts]
@@ -66,7 +66,7 @@ If Chinese, Japanese, Korean, Russian, Arabic, etc. characters render as empty b
     header_font = "Heiti SC"                        # heading uses CJK glyphs
     ```
 
-3. **Optionally override the header name** with `[personal] display_name` to replace the Latin "first (light) + last (bold)" split with a single styled string:
+3. **You can also replace the header name.** Set `[personal] display_name` to one styled string. It replaces the Latin split of first name (light) and last name (bold):
 
     ```toml
     [personal]
@@ -77,10 +77,10 @@ See the [Configuration Reference](configuration.md) for the complete `[layout.fo
 
 ## Typst Version Compatibility
 
-brilliant-CV requires **Typst 0.14.0** or newer (set in `typst.toml` as `compiler = "0.14.0"`). If you encounter unexpected errors, check your Typst version:
+brilliant-CV needs **Typst 0.14.0** or newer. `typst.toml` sets this as `compiler = "0.14.0"`. If you get unexpected errors, make sure that your Typst version is recent enough:
 
 ```bash
 typst --version
 ```
 
-Update to the latest Typst release if you're on an older version.
+If your version is older, update to the most recent Typst release.


### PR DESCRIPTION
## Why

Most readers of this project are not native English speakers. The hand-written docs were already reasonable (average sentence length 10-16 words), so this is not a readability rescue. The real find was **terminology drift**: the same concept carried different names across pages, which is exactly what a non-native reader cannot absorb.

`config` and `configuration` were both in use. `package`, `framework`, and `template` all referred to the shipped library in different places, even though `src/` and `template/` are different things in this repo. `folder` and `directory` alternated. `display` and `render` alternated for the same act.

## What changed

Six hand-written pages: `index.md`, `getting-started.md`, `troubleshooting.md`, `recipes.md`, `migration.md`, `components.md`.

The two generated pages are untouched. `api-reference.md` comes from `src/` doc-comments and `configuration.md` from `template/profile_en/metadata.toml` comments, so their prose is not editable here.

### Terminology, now fixed

| Concept | Use | Not |
|---|---|---|
| Configuration data | `configuration` | `config` |
| The published library | `package` | `framework` |
| The starter project a user copies | `template` | — |
| Filesystem location | `directory` | `folder` |
| Taking something away | `remove` | `delete` |
| What Typst puts on the page | `render` | `display` |
| Making information visible to a reader | `show` | `display` |
| Confirming a state | `make sure that` | `check`, `verify`, `confirm` |

`framework` as a name for the package went from 3 occurrences to 0.

### Sentence structure

Sentences over 25 words: 11 to 0. Average sentence length: 11.8 to 9.5 words. Long sentences were split, never truncated. No information was removed.

### Convention recorded

Second commit adds a `## Documentation Style` section to `AGENTS.md` so the terminology does not drift back on the next edit. It names the in-scope pages, explains how to change the generated pages instead, lists the untouchables, and carries the table above. It points at the [`simple-english` skill](https://github.com/AminBlg/SimpleEnglish) as the recommended tool. The skill is deliberately **not** vendored here; a pointer avoids carrying a third-party copy in this repo.

`CONTRIBUTING.md` gets one line pointing at that section for contributors who do not read `AGENTS.md`.

## Verification

`just docs-check` passes, and regenerating `api-reference.md` leaves the tree clean. `just ci-contract-check` passes.

**But note:** `just docs-check` does **not** gate these six files. `scripts/check_docs_snippets.py:13` pins `API_REFERENCE` to the generated page and compiles only its nine snippets. This PR records that fact in `AGENTS.md` so the next person does not mistake a green run for verification.

The actual check used here was a byte-level diff against the previous revision: every fenced code block, link target, and image reference is identical. Only prose changed. `recipes.md` gained two inline code spans (`cv-honor`, `cv-entry`) where a split sentence repeats a component name; nothing was removed.

## For the reviewer

- **`index.md` reads flatter now.** STE removes persuasion by design, so `feature-rich` is gone and `Get started in seconds` became `The Typst CLI creates a new project with one command`. This was a deliberate call to keep the page consistent with the rest; revert `index.md` alone if the landing page should keep its sales voice.
- **Two headings changed**, so their anchors changed: `Step 1: Bootstrap` to `Step 1: Initialize the Project`, and `Sharing config across profiles` to `Sharing configuration across profiles`. Nothing in the repo links to the old anchors; the five anchors that other pages do link to are unchanged.
- **One meaning shift**, flagged rather than hidden: `getting-started.md` Step 8 said `It is recommended to:` and now says `These steps are optional:`. STE has no way to express "recommended". The optionality survives; the endorsement does not.
- **Follow-up, not in this PR:** the two generated sources still use the old vocabulary. `src/` doc-comments rotate `display` and `render`; `template/profile_en/metadata.toml` comments are now the last place using `config`. A reader crossing from a hand-written page to a generated one will feel the shift.